### PR TITLE
improve error messages

### DIFF
--- a/src/dispatch/client.py
+++ b/src/dispatch/client.py
@@ -39,12 +39,16 @@ class Client:
         if not api_key:
             api_key = os.environ.get("DISPATCH_API_KEY")
         if not api_key:
-            raise ValueError("missing API key: set it with the DISPATCH_API_KEY environment variable")
+            raise ValueError(
+                "missing API key: set it with the DISPATCH_API_KEY environment variable"
+            )
 
         if not api_url:
             api_url = os.environ.get("DISPATCH_API_URL", DEFAULT_API_URL)
         if not api_url:
-            raise ValueError("missing API URL: set it with the DISPATCH_API_URL environment variable")
+            raise ValueError(
+                "missing API URL: set it with the DISPATCH_API_URL environment variable"
+            )
 
         self.api_url = api_url
         self.api_key = api_key

--- a/src/dispatch/fastapi.py
+++ b/src/dispatch/fastapi.py
@@ -84,14 +84,18 @@ class Dispatch(Registry):
             ValueError: If any of the required arguments are missing.
         """
         if not app:
-            raise ValueError("missing FastAPI app as first argument of the Dispatch constructor")
+            raise ValueError(
+                "missing FastAPI app as first argument of the Dispatch constructor"
+            )
 
-        endpoint_from = 'endpoint argument'
+        endpoint_from = "endpoint argument"
         if not endpoint:
             endpoint = os.getenv("DISPATCH_ENDPOINT_URL")
-            endpoint_from = 'DISPATCH_ENDPOINT_URL'
+            endpoint_from = "DISPATCH_ENDPOINT_URL"
         if not endpoint:
-            raise ValueError("missing application endpoint: set it with the DISPATCH_ENDPOINT_URL environment variable")
+            raise ValueError(
+                "missing application endpoint: set it with the DISPATCH_ENDPOINT_URL environment variable"
+            )
 
         if not verification_key:
             try:
@@ -112,13 +116,17 @@ class Dispatch(Registry):
 
         parsed_url = _urlparse.urlparse(endpoint)
         if not parsed_url.netloc or not parsed_url.scheme:
-            raise ValueError(f"{endpoint_from} must be a full URL with protocol and domain (e.g., https://example.com)")
+            raise ValueError(
+                f"{endpoint_from} must be a full URL with protocol and domain (e.g., https://example.com)"
+            )
 
         if verification_key:
             base64_key = base64.b64encode(verification_key.public_bytes_raw()).decode()
             logger.info("verifying request signatures using key %s", base64_key)
         else:
-            logger.warning("request verification is disabled because DISPATCH_VERIFICATION_KEY is not set")
+            logger.warning(
+                "request verification is disabled because DISPATCH_VERIFICATION_KEY is not set"
+            )
 
         client = Client(api_key=api_key, api_url=api_url)
         super().__init__(endpoint, client)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -31,7 +31,10 @@ class TestClient(unittest.TestCase):
     def test_api_key_missing(self):
         with self.assertRaises(ValueError) as mc:
             Client()
-        self.assertEqual(str(mc.exception), "missing API key: set it with the DISPATCH_API_KEY environment variable")
+        self.assertEqual(
+            str(mc.exception),
+            "missing API key: set it with the DISPATCH_API_KEY environment variable",
+        )
 
     def test_url_bad_scheme(self):
         with self.assertRaises(ValueError) as mc:

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -22,9 +22,10 @@ def create_dispatch_instance(app, endpoint):
     return Dispatch(
         app,
         endpoint=endpoint,
-        api_key='0000000000000000',
-        api_url='http://127.0.0.1:10000',
+        api_key="0000000000000000",
+        api_url="http://127.0.0.1:10000",
     )
+
 
 class TestFastAPI(unittest.TestCase):
     def test_Dispatch(self):
@@ -108,7 +109,9 @@ class TestCoroutine(unittest.TestCase):
         def root():
             return "OK"
 
-        self.dispatch = create_dispatch_instance(self.app, endpoint="https://127.0.0.1:9999")
+        self.dispatch = create_dispatch_instance(
+            self.app, endpoint="https://127.0.0.1:9999"
+        )
         self.http_client = TestClient(self.app)
         self.client = function_service.client(self.http_client)
 

--- a/tests/test_full.py
+++ b/tests/test_full.py
@@ -35,8 +35,8 @@ class TestFullFastapi(unittest.TestCase):
             self.app,
             endpoint="http://function-service",
             verification_key=public_key,
-            api_key='0000000000000000',
-            api_url='http://127.0.0.1:10000',
+            api_key="0000000000000000",
+            api_url="http://127.0.0.1:10000",
         )
 
         http_client = TestClient(self.app, base_url="http://dispatch-service")


### PR DESCRIPTION
This PR changes error messages to be more verbose and gives users more details about how to address the issues.

The PR also contains a few fixes:
- changes the mention of `DEFAULT_DISPATCH_API_URL` that was actually named `DEFAULT_API_URL` in the code
- make the API key and URL mandatory instead of silently disabling the construction of a `Client` in the `Dispatch` object; the intent is to avoid issues where the API key isn't set properly and the users have no clue why the program is crashing when trying to dispatch function calls