### PR TITLE
tests: fix dependency on os.environ

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -28,7 +28,7 @@ class TestClient(unittest.TestCase):
             client.dispatch([Call(function="my-function", input=42)])
         self.assertTrue("got 'Bearer WHATEVER'" in str(mc.exception))
 
-    @mock.patch.dict(os.environ, {"DISPATCH_API_KEY": ''})
+    @mock.patch.dict(os.environ, {"DISPATCH_API_KEY": ""})
     def test_api_key_missing(self):
         with self.assertRaises(ValueError) as mc:
             Client()

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -2,8 +2,8 @@ import logging
 import os
 import pickle
 import unittest
-from unittest import mock
 from typing import Any
+from unittest import mock
 
 import fastapi
 import google.protobuf.any_pb2
@@ -20,6 +20,7 @@ from dispatch.sdk.v1 import function_pb2 as function_pb
 from dispatch.status import Status
 
 from . import function_service
+
 
 def create_dispatch_instance(app, endpoint):
     return Dispatch(
@@ -62,7 +63,7 @@ class TestFastAPI(unittest.TestCase):
         with self.assertRaises(ValueError):
             create_dispatch_instance(None, endpoint="http://127.0.0.1:9999")
 
-    @mock.patch.dict(os.environ, {"DISPATCH_ENDPOINT_URL": ''})
+    @mock.patch.dict(os.environ, {"DISPATCH_ENDPOINT_URL": ""})
     def test_Dispatch_no_endpoint(self):
         app = fastapi.FastAPI()
         with self.assertRaises(ValueError):


### PR DESCRIPTION
This PR ensures that our tests do not depend on environment variables being unset to pass.