### PR TITLE
fix repositories in fanount example

### DIFF
--- a/examples/fanout/fanout.py
+++ b/examples/fanout/fanout.py
@@ -55,8 +55,7 @@ async def fanout():
     # Using gather, we fan-out the four following requests.
     repos = await gather(
         get_repo("stealthrocket", "coroutine"),
-        get_repo("stealthrocket", "timecraft"),
-        get_repo("stealthrocket", "dispatch-sdk-python"),
+        get_repo("stealthrocket", "dispatch-py"),
         get_repo("stealthrocket", "wzprof"),
     )
 


### PR DESCRIPTION
- remove timecraft from the examples since we archived the repository
- rename dispatch-sdk-python to dispatch-py