### PR TITLE
remove httpx dependency from dispatch.fastapi module

### DIFF
--- a/src/dispatch/fastapi.py
+++ b/src/dispatch/fastapi.py
@@ -21,11 +21,11 @@ import base64
 import logging
 import os
 from datetime import timedelta
+from urllib.parse import urlparse
 
 import fastapi
 import fastapi.responses
 from http_message_signatures import InvalidSignature
-from httpx import _urlparse
 
 from dispatch.client import Client
 from dispatch.function import Registry
@@ -116,7 +116,7 @@ class Dispatch(Registry):
 
         logger.info("configuring Dispatch endpoint %s", endpoint)
 
-        parsed_url = _urlparse.urlparse(endpoint)
+        parsed_url = urlparse(endpoint)
         if not parsed_url.netloc or not parsed_url.scheme:
             raise ValueError(
                 f"{endpoint_from} must be a full URL with protocol and domain (e.g., https://example.com)"


### PR DESCRIPTION
We were depending on `httpx` only for the `_urlparse` function. I believe `urllib` is less strict and could let through URLs that miss required fields, we can address these later.

Note that we still have a dev dependency on `httpx`, this PR only removes the dependency from the core SDK.

Fixes #112 