### PR TITLE
Batch submit

### DIFF
--- a/src/dispatch/fastapi.py
+++ b/src/dispatch/fastapi.py
@@ -27,7 +27,7 @@ import fastapi
 import fastapi.responses
 from http_message_signatures import InvalidSignature
 
-from dispatch.client import Client
+from dispatch.client import Batch, Client
 from dispatch.function import Registry
 from dispatch.proto import Input
 from dispatch.sdk.v1 import function_pb2 as function_pb
@@ -47,7 +47,7 @@ logger = logging.getLogger(__name__)
 class Dispatch(Registry):
     """A Dispatch programmable endpoint, powered by FastAPI."""
 
-    __slots__ = ()
+    __slots__ = ("client",)
 
     def __init__(
         self,
@@ -116,11 +116,16 @@ class Dispatch(Registry):
                 "request verification is disabled because DISPATCH_VERIFICATION_KEY is not set"
             )
 
-        client = Client(api_key=api_key, api_url=api_url)
-        super().__init__(endpoint, client)
+        self.client = Client(api_key=api_key, api_url=api_url)
+        super().__init__(endpoint, self.client)
 
         function_service = _new_app(self, verification_key)
         app.mount("/dispatch.sdk.v1.FunctionService", function_service)
+
+    def batch(self) -> Batch:
+        """Returns a Batch instance that can be used to build
+        a set of calls to dispatch."""
+        return self.client.batch()
 
 
 def parse_verification_key(


### PR DESCRIPTION
Users can dispatch a set of calls using the low-level `Client`:

```python
class Client:
  def dispatch(calls: Iterable[Call]) -> list[DispatchID])
```

We construct a `Client` instance when users use the FastAPI integration, but we don't currently export the client instance.

We provide sugar for dispatching a single call like so:

```python
@dispatch.function
def foo(bar: int): ...

foo.dispatch(1)  # sugar for: client.dispatch([foo.build_call(1)])
``` 

We don't provide any sugar for dispatching more than one call to a single function, or to many functions in the same batch.

This PR fixes the issue by providing a way to build and dispatch a batch of calls:

```python
batch = dispatch.batch()

batch.add(func1.build_call(...))
     .add(func2.build_call(...))
     .add(func3.build_call(...))
         
batch.dispatch()
```