### PR TITLE
Fix registration of synchronous functions

### DIFF
--- a/src/dispatch/function.py
+++ b/src/dispatch/function.py
@@ -182,28 +182,28 @@ class Registry:
 
     def function(self, func):
         """Decorator that registers functions."""
+        name = func.__qualname__
         if not inspect.iscoroutinefunction(func):
-            logger.info("registering function: %s", func.__qualname__)
-            return self._register_function(func)
+            logger.info("registering function: %s", name)
+            return self._register_function(name, func)
 
-        logger.info("registering coroutine: %s", func.__qualname__)
-        return self._register_coroutine(func)
+        logger.info("registering coroutine: %s", name)
+        return self._register_coroutine(name, func)
 
-    def _register_function(self, func: Callable[P, T]) -> Function[P, T]:
+    def _register_function(self, name: str, func: Callable[P, T]) -> Function[P, T]:
         func = durable(func)
 
         @wraps(func)
         async def async_wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
             return func(*args, **kwargs)
 
-        async_wrapper.__qualname__ = f"{func.__qualname__}_async"
+        async_wrapper.__qualname__ = f"{name}_async"
 
-        return self._register_coroutine(async_wrapper)
+        return self._register_coroutine(name, async_wrapper)
 
     def _register_coroutine(
-        self, func: Callable[P, Coroutine[Any, Any, T]]
+        self, name: str, func: Callable[P, Coroutine[Any, Any, T]]
     ) -> Function[P, T]:
-        name = func.__qualname__
         logger.info("registering coroutine: %s", name)
 
         func = durable(func)

--- a/tests/test_full.py
+++ b/tests/test_full.py
@@ -59,6 +59,9 @@ class TestFullFastapi(unittest.TestCase):
         def my_function(name: str) -> str:
             return f"Hello world: {name}"
 
+        call = my_function.build_call(52)
+        self.assertEqual(call.function.split(".")[-1], "my_function")
+
         # The client.
         [dispatch_id] = self.dispatch_client.dispatch([my_function.build_call(52)])
 
@@ -73,10 +76,13 @@ class TestFullFastapi(unittest.TestCase):
 
     def test_simple_missing_signature(self):
         @self.dispatch.function
-        def my_function(name: str) -> str:
+        async def my_function(name: str) -> str:
             return f"Hello world: {name}"
 
-        [dispatch_id] = self.dispatch_client.dispatch([my_function.build_call(52)])
+        call = my_function.build_call(52)
+        self.assertEqual(call.function.split(".")[-1], "my_function")
+
+        [dispatch_id] = self.dispatch_client.dispatch([call])
 
         self.dispatch_service.endpoint_client = EndpointClient.from_app(
             self.endpoint_app


### PR DESCRIPTION
This fixes a bug where synchronous functions are registered with an incorrect function name (`{func.__qualname__}_async`).