### PR TITLE
Slack integration

### DIFF
--- a/src/dispatch/integrations/__init__.py
+++ b/src/dispatch/integrations/__init__.py
@@ -6,7 +6,7 @@ logger = logging.getLogger(__name__)
 
 # Automatically register error and output types from
 # commonly used libraries.
-integrations = ("httpx", "requests")
+integrations = ("httpx", "requests", "slack")
 for name in integrations:
     try:
         importlib.import_module(f"dispatch.integrations.{name}")

--- a/src/dispatch/integrations/slack.py
+++ b/src/dispatch/integrations/slack.py
@@ -1,0 +1,27 @@
+import slack_sdk
+import slack_sdk.errors
+import slack_sdk.web
+
+from dispatch.integrations.http import http_response_code_status
+from dispatch.status import Status, register_error_type, register_output_type
+
+
+def slack_error_status(error: Exception) -> Status:
+    # See https://github.com/slackapi/python-slack-sdk/blob/main/slack/errors.py
+    match error:
+        case slack_sdk.errors.SlackApiError():
+            if error.response is not None:
+                return slack_response_status(error.response)
+
+    return Status.TEMPORARY_ERROR
+
+
+def slack_response_status(response: slack_sdk.web.SlackResponse) -> Status:
+    return http_response_code_status(response.status_code)
+
+
+# Register types of things that a function might return.
+register_output_type(slack_sdk.web.SlackResponse, slack_response_status)
+
+# Register base exception.
+register_error_type(slack_sdk.errors.SlackClientError, slack_error_status)

--- a/src/dispatch/integrations/slack.py
+++ b/src/dispatch/integrations/slack.py
@@ -1,6 +1,6 @@
-import slack_sdk
-import slack_sdk.errors
-import slack_sdk.web
+import slack_sdk  # type: ignore
+import slack_sdk.errors  # type: ignore
+import slack_sdk.web  # type: ignore
 
 from dispatch.integrations.http import http_response_code_status
 from dispatch.status import Status, register_error_type, register_output_type


### PR DESCRIPTION
This PR adds an integration for the [Slack SDK](https://github.com/slackapi/python-slack-sdk). If exceptions such as `slack_sdk.errors.SlackApiError` are raised, the error will be categorized correctly so that temporary errors are automatically retried.