### PR TITLE
Remote endpoints

### DIFF
--- a/src/dispatch/__init__.py
+++ b/src/dispatch/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import dispatch.integrations
 from dispatch.coroutine import all, any, call, gather, race
-from dispatch.function import DEFAULT_API_URL, Client
+from dispatch.function import DEFAULT_API_URL, Client, Registry
 from dispatch.id import DispatchID
 from dispatch.proto import Call, Error, Input, Output
 from dispatch.status import Status
@@ -23,4 +23,5 @@ __all__ = [
     "all",
     "any",
     "race",
+    "Registry",
 ]

--- a/src/dispatch/fastapi.py
+++ b/src/dispatch/fastapi.py
@@ -115,8 +115,7 @@ class Dispatch(Registry):
                 "request verification is disabled because DISPATCH_VERIFICATION_KEY is not set"
             )
 
-        self.client = Client(api_key=api_key, api_url=api_url)
-        super().__init__(endpoint, self.client)
+        super().__init__(endpoint, api_key=api_key, api_url=api_url)
 
         function_service = _new_app(self, verification_key)
         app.mount("/dispatch.sdk.v1.FunctionService", function_service)
@@ -225,7 +224,7 @@ def _new_app(function_registry: Dispatch, verification_key: Ed25519PublicKey | N
             raise _ConnectError(400, "invalid_argument", "function is required")
 
         try:
-            func = function_registry._functions[req.function]
+            func = function_registry.functions[req.function]
         except KeyError:
             logger.debug("function '%s' not found", req.function)
             raise _ConnectError(

--- a/tests/dispatch/test_function.py
+++ b/tests/dispatch/test_function.py
@@ -6,8 +6,11 @@ from dispatch.function import Client, Registry
 
 class TestFunction(unittest.TestCase):
     def setUp(self):
-        self.client = Client(api_url="http://dispatch.com", api_key="foobar")
-        self.dispatch = Registry(endpoint="http://example.com", client=self.client)
+        self.dispatch = Registry(
+            endpoint="http://example.com",
+            api_url="http://dispatch.com",
+            api_key="foobar",
+        )
 
     def test_serializable(self):
         @self.dispatch.function


### PR DESCRIPTION
This PR reworks the `Registry` class so that it can be used to register and dispatch calls to functions hosted on remote endpoints.

```python
from dispatch import Registry

remote = Registry("http://some.foreign.endpoint/")

@remote.function
def foo(bar: int) -> str: ...
```

You only need to register a stub for remote functions. You can then dispatch calls to them (e.g. `foo.dispatch(bar)`), and also use them within a local function/coroutine (e.g. `await foo(bar)`). Type checking works as expected in both cases.