### PR TITLE
Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,11 +100,11 @@ The following code snippet is a complete example showing how to install a
 
 ```python
 from fastapi import FastAPI
-from dispatch.fastapi import Dispatch
+from dispatch.fastapi import Endpoint
 import requests
 
 app = FastAPI()
-dispatch = Dispatch(app)
+dispatch = Endpoint(app)
 
 @dispatch.function
 def publish(url, payload):

--- a/examples/auto_retry/app.py
+++ b/examples/auto_retry/app.py
@@ -22,7 +22,7 @@ import random
 import requests
 from fastapi import FastAPI
 
-from dispatch.fastapi import Dispatch
+from dispatch.fastapi import Endpoint
 
 # Create the FastAPI app like you normally would.
 app = FastAPI()
@@ -32,7 +32,7 @@ rng = random.Random(2)
 
 # Create a Dispatch instance and pass the FastAPI app to it. It automatically
 # sets up the necessary routes and handlers.
-dispatch = Dispatch(app)
+dispatch = Endpoint(app)
 
 
 def third_party_api_call(x):

--- a/examples/fanout/fanout.py
+++ b/examples/fanout/fanout.py
@@ -15,11 +15,11 @@ import httpx
 from fastapi import FastAPI
 
 from dispatch import gather
-from dispatch.fastapi import Dispatch
+from dispatch.fastapi import Endpoint
 
 app = FastAPI()
 
-dispatch = Dispatch(app)
+dispatch = Endpoint(app)
 
 
 @dispatch.function

--- a/examples/getting_started/app.py
+++ b/examples/getting_started/app.py
@@ -57,14 +57,14 @@ curl http://localhost:8000/
 import requests
 from fastapi import FastAPI
 
-from dispatch.fastapi import Dispatch
+from dispatch.fastapi import Endpoint
 
 # Create the FastAPI app like you normally would.
 app = FastAPI()
 
 # Create a Dispatch instance and pass the FastAPI app to it. It automatically
 # sets up the necessary routes and handlers.
-dispatch = Dispatch(app)
+dispatch = Endpoint(app)
 
 
 # Use the `dispatch.function` decorator declare a stateful function.

--- a/examples/github_stats/app.py
+++ b/examples/github_stats/app.py
@@ -17,11 +17,11 @@ Logs will show a pipeline of functions being called and their results.
 import httpx
 from fastapi import FastAPI
 
-from dispatch.fastapi import Dispatch
+from dispatch.fastapi import Endpoint
 
 app = FastAPI()
 
-dispatch = Dispatch(app)
+dispatch = Endpoint(app)
 
 
 def get_gh_api(url):

--- a/src/dispatch/__init__.py
+++ b/src/dispatch/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import dispatch.integrations
 from dispatch.coroutine import all, any, call, gather, race
-from dispatch.function import DEFAULT_API_URL, Client, Registry
+from dispatch.function import DEFAULT_API_URL, Client
 from dispatch.id import DispatchID
 from dispatch.proto import Call, Error, Input, Output
 from dispatch.status import Status
@@ -23,5 +23,4 @@ __all__ = [
     "all",
     "any",
     "race",
-    "Registry",
 ]

--- a/src/dispatch/remote.py
+++ b/src/dispatch/remote.py
@@ -1,0 +1,5 @@
+from dispatch.function import Registry
+
+
+class Endpoint(Registry):
+    """A remote registry of functions."""

--- a/tests/dispatch/test_function.py
+++ b/tests/dispatch/test_function.py
@@ -1,12 +1,12 @@
 import pickle
 import unittest
 
-from dispatch.function import Client, Registry
+from dispatch.remote import Endpoint
 
 
 class TestFunction(unittest.TestCase):
     def setUp(self):
-        self.dispatch = Registry(
+        self.dispatch = Endpoint(
             endpoint="http://example.com",
             api_url="http://dispatch.com",
             api_key="foobar",

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -13,7 +13,7 @@ from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 from fastapi.testclient import TestClient
 
 from dispatch.experimental.durable.registry import clear_functions
-from dispatch.fastapi import Dispatch, parse_verification_key
+from dispatch.fastapi import Endpoint, parse_verification_key
 from dispatch.function import Arguments, Error, Function, Input, Output
 from dispatch.proto import _any_unpickle as any_unpickle
 from dispatch.sdk.v1 import call_pb2 as call_pb
@@ -30,7 +30,7 @@ public_key_b64 = base64.b64encode(public_key_bytes)
 
 
 def create_dispatch_instance(app, endpoint):
-    return Dispatch(
+    return Endpoint(
         app,
         endpoint=endpoint,
         api_key="0000000000000000",

--- a/tests/test_full.py
+++ b/tests/test_full.py
@@ -4,7 +4,7 @@ import fastapi
 import httpx
 
 import dispatch
-from dispatch.fastapi import Dispatch
+from dispatch.fastapi import Endpoint
 from dispatch.proto import _any_unpickle as any_unpickle
 from dispatch.signature import private_key_from_pem, public_key_from_pem
 from dispatch.test import DispatchServer, DispatchService, EndpointClient
@@ -40,7 +40,7 @@ class TestFullFastapi(unittest.TestCase):
             api_key, api_url=self.dispatch_server.url
         )
 
-        self.dispatch = Dispatch(
+        self.dispatch = Endpoint(
             self.endpoint_app,
             endpoint="http://function-service",  # unused
             verification_key=verification_key,


### PR DESCRIPTION
This PR changes the import scheme so that the construction of local and remote endpoints is clearer. 

For remote endpoints:

```python
from dispatch.remote import Endpoint

remote = Endpoint(url)

@remote.function
def my_remote_func(): ...
```

For local endpoints (e.g. using FastAPI):

```python
from fastapi import FastAPI
from dispatch.fastapi import Endpoint

app = FastAPI()
dispatch = Endpoint(app)

@dispatch.function
def my_local_func(): ...
```

Previously you had `from dispatch.fastapi import Dispatch` for local endpoints, and `from dispatch import Registry` for remote endpoints (#134).

With this PR we avoid using the ambiguous `Dispatch` and `Registry` names, and the ambiguous top-level namespace (`from dispatch import $thing`).

I've maintained backward compatibility by creating a `dispatch.fastapi.{Dispatch => Endpoint}` alias (so `from dispatch.fastapi import Dispatch` continues to work).