### PR TITLE
Python 3.10 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.11', '3.12']
+        python: ['3.10', '3.11', '3.12']
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "dispatch-py"
 description = "Develop reliable distributed systems on the Dispatch platform."
 readme = "README.md"
 dynamic = ["version"]
-requires-python = ">= 3.11"
+requires-python = ">= 3.10"
 dependencies = [
     "grpcio >= 1.60.0",
     "protobuf >= 4.24.0",

--- a/src/dispatch/experimental/durable/frame.c
+++ b/src/dispatch/experimental/durable/frame.c
@@ -373,7 +373,11 @@ void set_frame_lasti(Frame *frame, int lasti) {
 
 static int get_frame_state(PyGenObject *gen_like) {
 #if PY_MINOR_VERSION == 10
-    return get_frame(gen_like)->f_state;
+    Frame *frame = (Frame *)(gen_like->gi_frame);
+    if (!frame) {
+        return FRAME_CLEARED;
+    }
+    return frame->f_state;
 #elif PY_MINOR_VERSION == 11
     return gen_like->gi_frame_state;
 #elif PY_MINOR_VERSION == 12

--- a/src/dispatch/experimental/durable/frame.c
+++ b/src/dispatch/experimental/durable/frame.c
@@ -490,8 +490,9 @@ void set_frame_iblock(Frame *frame, int iblock) {
     assert(iblock >= 0 && iblock < get_frame_iblock_limit(frame));
 #if PY_MINOR_VERSION == 10
     frame->f_iblock = iblock;
-#endif
+#else
     assert(!iblock); // not applicable >= 3.11
+#endif
 }
 
 static PyTryBlock *get_frame_blockstack(Frame *frame) {

--- a/src/dispatch/experimental/durable/frame.c
+++ b/src/dispatch/experimental/durable/frame.c
@@ -80,24 +80,7 @@ typedef struct InterpreterFrame {
 #endif
 } InterpreterFrame;
 
-// This is a redefinition of the private PyFrameObject (aka. struct _frame):
-// https://github.com/python/cpython/blob/3.10/Include/cpython/frameobject.h#L28
-// https://github.com/python/cpython/blob/3.11/Include/internal/pycore_frame.h#L15
-// https://github.com/python/cpython/blob/3.12/Include/internal/pycore_frame.h#L16
-// https://github.com/python/cpython/blob/v3.13.0a5/Include/internal/pycore_frame.h#L20
-typedef struct FrameObject {
-    PyObject_HEAD
-    PyFrameObject *f_back;
-    struct _PyInterpreterFrame *f_frame;
-    PyObject *f_trace;
-    int f_lineno;
-    char f_trace_lines;
-    char f_trace_opcodes;
-    char f_fast_as_locals;
-    PyObject *_f_frame_data[1];
-} FrameObject;
-
-// This is a redefinition of frame state constants:
+// This is a redefinition of private frame state constants:
 typedef enum _framestate {
 #if PY_MINOR_VERSION == 10
 // https://github.com/python/cpython/blob/3.10/Include/cpython/frameobject.h#L10
@@ -142,6 +125,68 @@ typedef struct {
     PyObject_HEAD
     PyCoroObject *cw_coroutine;
 } PyCoroWrapper;
+
+/*
+// This is the definition of PyFrameObject (aka. struct _frame) for reference
+// to developers working on the extension.
+//
+typedef struct {
+#if PY_MINOR_VERSION == 10
+// https://github.com/python/cpython/blob/3.10/Include/cpython/frameobject.h#L28
+    PyObject_VAR_HEAD
+    struct InterpreterFrame *f_back; // struct _frame
+    PyCodeObject *f_code;
+    PyObject *f_builtins;
+    PyObject *f_globals;
+    PyObject *f_locals;
+    PyObject **f_valuestack;
+    PyObject *f_trace;
+    int f_stackdepth;
+    char f_trace_lines;
+    char f_trace_opcodes;
+    PyObject *f_gen;
+    int f_lasti;
+    int f_lineno;
+    int f_iblock;
+    PyFrameState f_state;
+    PyTryBlock f_blockstack[CO_MAXBLOCKS];
+    PyObject *f_localsplus[1];
+#elif PY_MINOR_VERSION == 11
+// https://github.com/python/cpython/blob/3.11/Include/internal/pycore_frame.h#L15
+    PyObject_HEAD
+    PyFrameObject *f_back;
+    struct _PyInterpreterFrame *f_frame;
+    PyObject *f_trace;
+    int f_lineno;
+    char f_trace_lines;
+    char f_trace_opcodes;
+    char f_fast_as_locals;
+    PyObject *_f_frame_data[1];
+#elif PY_MINOR_VERSION == 12
+// https://github.com/python/cpython/blob/3.12/Include/internal/pycore_frame.h#L16
+    PyObject_HEAD
+    PyFrameObject *f_back;
+    struct _PyInterpreterFrame *f_frame;
+    PyObject *f_trace;
+    int f_lineno;
+    char f_trace_lines;
+    char f_trace_opcodes;
+    char f_fast_as_locals;
+    PyObject *_f_frame_data[1];
+#elif PY_MINOR_VERSION == 13
+// https://github.com/python/cpython/blob/v3.13.0a5/Include/internal/pycore_frame.h#L20
+    PyObject_HEAD
+    PyFrameObject *f_back;
+    struct _PyInterpreterFrame *f_frame;
+    PyObject *f_trace;
+    int f_lineno;
+    char f_trace_lines;
+    char f_trace_opcodes;
+    char f_fast_as_locals;
+    PyObject *_f_frame_data[1];
+#endif
+} PyFrameObject;
+*/
 
 /*
 // This is the definition of PyGenObject for reference to developers

--- a/src/dispatch/experimental/durable/frame.c
+++ b/src/dispatch/experimental/durable/frame.c
@@ -353,7 +353,7 @@ static int get_frame_lasti(Frame *frame) {
 #endif
 }
 
-void set_frame_lasti(Frame *frame, int lasti) {
+static void set_frame_lasti(Frame *frame, int lasti) {
 #if PY_MINOR_VERSION == 10
     frame->f_lasti = lasti;
 #elif PY_MINOR_VERSION == 11
@@ -486,7 +486,7 @@ static int get_frame_iblock(Frame *frame) {
     return 0; // not applicable >= 3.11
 }
 
-void set_frame_iblock(Frame *frame, int iblock) {
+static void set_frame_iblock(Frame *frame, int iblock) {
     assert(iblock >= 0 && iblock < get_frame_iblock_limit(frame));
 #if PY_MINOR_VERSION == 10
     frame->f_iblock = iblock;

--- a/src/dispatch/experimental/durable/frame.c
+++ b/src/dispatch/experimental/durable/frame.c
@@ -641,7 +641,7 @@ static PyObject *ext_get_frame_block_at(PyObject *self, PyObject *args) {
     }
     PyTryBlock *blockstack = get_frame_blockstack(frame);
     PyTryBlock *block = &blockstack[index];
-    return PyTuple_Pack(3, block->b_type, block->b_handler, block->b_level);
+    return Py_BuildValue("(iii)", block->b_type, block->b_handler, block->b_level);
 }
 
 static PyObject *ext_set_frame_ip(PyObject *self, PyObject *args) {

--- a/src/dispatch/experimental/durable/frame.c
+++ b/src/dispatch/experimental/durable/frame.c
@@ -22,7 +22,7 @@ typedef struct _PyTryBlock {
 
 // This is a redefinition of the private/opaque frame object.
 // In Python 3.10 and prior, `struct _frame` is both the PyFrameObject and
-// PyFrame. From Python 3.11 onwards, the two were split with the
+// PyInterpreterFrame. From Python 3.11 onwards, the two were split with the
 // PyFrameObject (struct _frame) pointing to struct _PyInterpreterFrame.
 typedef struct Frame {
 #if PY_MINOR_VERSION == 10

--- a/src/dispatch/experimental/durable/frame.pyi
+++ b/src/dispatch/experimental/durable/frame.pyi
@@ -13,6 +13,12 @@ def get_frame_sp(frame: FrameType | Coroutine | Generator | AsyncGenerator) -> i
 def set_frame_sp(frame: FrameType | Coroutine | Generator | AsyncGenerator, sp: int):
     """Set stack pointer of a generator or coroutine."""
 
+def get_frame_bp(frame: FrameType | Coroutine | Generator | AsyncGenerator) -> int:
+    """Get block pointer of a generator or coroutine."""
+
+def set_frame_bp(frame: FrameType | Coroutine | Generator | AsyncGenerator, bp: int):
+    """Set block pointer of a generator or coroutine."""
+
 def get_frame_stack_at(
     frame: FrameType | Coroutine | Generator | AsyncGenerator, index: int
 ) -> Tuple[bool, Any]:

--- a/src/dispatch/experimental/durable/frame.pyi
+++ b/src/dispatch/experimental/durable/frame.pyi
@@ -32,6 +32,18 @@ def set_frame_stack_at(
 ):
     """Set or unset an object on the stack of a generator or coroutine."""
 
+def get_frame_block_at(
+    frame: FrameType | Coroutine | Generator | AsyncGenerator, index: int
+) -> Tuple[int, int, int]:
+    """Get a block from a generator or coroutine."""
+
+def set_frame_block_at(
+    frame: FrameType | Coroutine | Generator | AsyncGenerator,
+    index: int,
+    value: Tuple[int, int, int],
+):
+    """Restore a block of a generator or coroutine."""
+
 def get_frame_state(
     frame: FrameType | Coroutine | Generator | AsyncGenerator,
 ) -> int:

--- a/src/dispatch/experimental/durable/frame310.h
+++ b/src/dispatch/experimental/durable/frame310.h
@@ -1,0 +1,151 @@
+// This is a redefinition of the private PyFrameState.
+// https://github.com/python/cpython/blob/3.10/Include/cpython/frameobject.h#L20
+typedef int8_t PyFrameState;
+
+// This is a redefinition of the private/opaque frame object.
+// https://github.com/python/cpython/blob/3.10/Include/cpython/frameobject.h#L28
+//
+// In Python 3.10, `struct _frame` is both the PyFrameObject and
+// PyInterpreterFrame. From Python 3.11 onwards, the two were split with the
+// PyFrameObject (struct _frame) pointing to struct _PyInterpreterFrame.
+struct Frame {
+    PyObject_VAR_HEAD
+    struct Frame *f_back; // struct _frame
+    PyCodeObject *f_code;
+    PyObject *f_builtins;
+    PyObject *f_globals;
+    PyObject *f_locals;
+    PyObject **f_valuestack;
+    PyObject *f_trace;
+    int f_stackdepth;
+    char f_trace_lines;
+    char f_trace_opcodes;
+    PyObject *f_gen;
+    int f_lasti;
+    int f_lineno;
+    int f_iblock;
+    PyFrameState f_state;
+    PyTryBlock f_blockstack[CO_MAXBLOCKS];
+    PyObject *f_localsplus[1];
+};
+
+// This is a redefinition of private frame state constants.
+// https://github.com/python/cpython/blob/3.10/Include/cpython/frameobject.h#L10
+typedef enum _framestate {
+    FRAME_CREATED = -2,
+    FRAME_SUSPENDED = -1,
+    FRAME_EXECUTING = 0,
+    FRAME_RETURNED = 1,
+    FRAME_UNWINDING = 2,
+    FRAME_RAISED = 3,
+    FRAME_CLEARED = 4
+} FrameState;
+
+/*
+// This is the definition of PyGenObject for reference to developers
+// working on the extension.
+//
+// Note that PyCoroObject and PyAsyncGenObject have the same layout as
+// PyGenObject, however the struct fields have a cr_ and ag_ prefix
+// (respectively) rather than a gi_ prefix. In Python 3.10, PyCoroObject
+// and PyAsyncGenObject have extra fields compared to PyGenObject. In Python
+// 3.11 onwards, the three objects are identical (except for field name
+// prefixes). The extra fields in Python 3.10 are not applicable to this
+// extension at this time.
+//
+// https://github.com/python/cpython/blob/3.10/Include/genobject.h#L16
+typedef struct {
+    PyObject_HEAD
+    PyFrameObject *gi_frame;
+    PyObject *gi_code;
+    PyObject *gi_weakreflist;
+    PyObject *gi_name;
+    PyObject *gi_qualname;
+    _PyErr_StackItem gi_exc_state;
+} PyGenObject;
+*/
+
+static Frame *get_frame(PyGenObject *gen_like) {
+    Frame *frame = (Frame *)(gen_like->gi_frame);
+    assert(frame);
+    return frame;
+}
+
+static PyCodeObject *get_frame_code(Frame *frame) {
+    PyCodeObject *code = frame->f_code;
+    assert(code);
+    return code;
+}
+
+static int get_frame_lasti(Frame *frame) {
+    return frame->f_lasti;
+}
+
+static void set_frame_lasti(Frame *frame, int lasti) {
+    frame->f_lasti = lasti;
+}
+
+static int get_frame_state(PyGenObject *gen_like) {
+    Frame *frame = (Frame *)(gen_like->gi_frame);
+    if (!frame) {
+        return FRAME_CLEARED;
+    }
+    return frame->f_state;
+}
+
+static void set_frame_state(PyGenObject *gen_like, int fs) {
+    Frame *frame = get_frame(gen_like);
+    frame->f_state = (PyFrameState)fs;
+}
+
+static int valid_frame_state(int fs) {
+    return fs == FRAME_CREATED || fs == FRAME_SUSPENDED || fs == FRAME_EXECUTING || fs == FRAME_RETURNED || fs == FRAME_UNWINDING || fs == FRAME_RAISED || fs == FRAME_CLEARED;
+}
+
+static int get_frame_stacktop_limit(Frame *frame) {
+    PyCodeObject *code = get_frame_code(frame);
+    return code->co_stacksize + code->co_nlocals;
+}
+
+static int get_frame_stacktop(Frame *frame) {
+    assert(frame->f_localsplus);
+    assert(frame->f_valuestack);
+    int stacktop = (int)(frame->f_valuestack - frame->f_localsplus) + frame->f_stackdepth;
+    assert(stacktop >= 0 && stacktop < get_frame_stacktop_limit(frame));
+    return stacktop;
+}
+
+static void set_frame_stacktop(Frame *frame, int stacktop) {
+    assert(stacktop >= 0 && stacktop < get_frame_stacktop_limit(frame));
+    assert(frame->f_localsplus);
+    assert(frame->f_valuestack);
+    int base = (int)(frame->f_valuestack - frame->f_localsplus);
+    assert(stacktop >= base);
+    frame->f_stackdepth = stacktop - base;
+}
+
+static PyObject **get_frame_localsplus(Frame *frame) {
+    PyObject **localsplus = frame->f_localsplus;
+    assert(localsplus);
+    return localsplus;
+}
+
+static int get_frame_iblock_limit(Frame *frame) {
+    return CO_MAXBLOCKS;
+}
+
+static int get_frame_iblock(Frame *frame) {
+    return frame->f_iblock;
+}
+
+static void set_frame_iblock(Frame *frame, int iblock) {
+    assert(iblock >= 0 && iblock < get_frame_iblock_limit(frame));
+    frame->f_iblock = iblock;
+}
+
+static PyTryBlock *get_frame_blockstack(Frame *frame) {
+    PyTryBlock *blockstack = frame->f_blockstack;
+    assert(blockstack);
+    return blockstack;
+}
+

--- a/src/dispatch/experimental/durable/frame311.h
+++ b/src/dispatch/experimental/durable/frame311.h
@@ -1,0 +1,148 @@
+// This is a redefinition of the private/opaque frame object.
+// https://github.com/python/cpython/blob/3.11/Include/internal/pycore_frame.h#L47
+//
+// In Python 3.10 and prior, `struct _frame` is both the PyFrameObject and
+// PyInterpreterFrame. From Python 3.11 onwards, the two were split with the
+// PyFrameObject (struct _frame) pointing to struct _PyInterpreterFrame.
+struct Frame {
+    PyFunctionObject *f_func;
+    PyObject *f_globals;
+    PyObject *f_builtins;
+    PyObject *f_locals;
+    PyCodeObject *f_code;
+    PyFrameObject *frame_obj;
+    struct Frame *previous; // struct _PyInterpreterFrame
+    _Py_CODEUNIT *prev_instr;
+    int stacktop;
+    bool is_entry;
+    char owner;
+    PyObject *localsplus[1];
+};
+
+// This is a redefinition of private frame state constants.
+// https://github.com/python/cpython/blob/3.11/Include/internal/pycore_frame.h#L33
+typedef enum _framestate {
+    FRAME_CREATED = -2,
+    FRAME_SUSPENDED = -1,
+    FRAME_EXECUTING = 0,
+    FRAME_COMPLETED = 1,
+    FRAME_CLEARED = 4
+} FrameState;
+
+/*
+// This is the definition of PyFrameObject (aka. struct _frame) for reference
+// to developers working on the extension.
+//
+// https://github.com/python/cpython/blob/3.11/Include/internal/pycore_frame.h#L15
+typedef struct {
+    PyObject_HEAD
+    PyFrameObject *f_back;
+    struct _PyInterpreterFrame *f_frame;
+    PyObject *f_trace;
+    int f_lineno;
+    char f_trace_lines;
+    char f_trace_opcodes;
+    char f_fast_as_locals;
+    PyObject *_f_frame_data[1];
+} PyFrameObject;
+*/
+
+/*
+// This is the definition of PyGenObject for reference to developers
+// working on the extension.
+//
+// Note that PyCoroObject and PyAsyncGenObject have the same layout as
+// PyGenObject, however the struct fields have a cr_ and ag_ prefix
+// (respectively) rather than a gi_ prefix.
+//
+// https://github.com/python/cpython/blob/3.11/Include/cpython/genobject.h#L14
+typedef struct {
+    PyObject_HEAD
+    PyCodeObject *gi_code;
+    PyObject *gi_weakreflist;
+    PyObject *gi_name;
+    PyObject *gi_qualname;
+    _PyErr_StackItem gi_exc_state;
+    PyObject *gi_origin_or_finalizer;
+    char gi_hooks_inited;
+    char gi_closed;
+    char gi_running_async;
+    int8_t gi_frame_state;
+    PyObject *gi_iframe[1];
+} PyGenObject;
+*/
+
+static Frame *get_frame(PyGenObject *gen_like) {
+    Frame *frame = (Frame *)(struct _PyInterpreterFrame *)(gen_like->gi_iframe);
+    assert(frame);
+    return frame;
+}
+
+static PyCodeObject *get_frame_code(Frame *frame) {
+    PyCodeObject *code = frame->f_code;
+    assert(code);
+    return code;
+}
+
+static int get_frame_lasti(Frame *frame) {
+    // https://github.com/python/cpython/blob/3.11/Include/internal/pycore_frame.h#L69
+    PyCodeObject *code = get_frame_code(frame);
+    assert(frame->prev_instr);
+    return (int)((intptr_t)frame->prev_instr - (intptr_t)_PyCode_CODE(code));
+}
+
+static void set_frame_lasti(Frame *frame, int lasti) {
+    // https://github.com/python/cpython/blob/3.11/Include/internal/pycore_frame.h#L69
+    PyCodeObject *code = get_frame_code(frame);
+    frame->prev_instr = (_Py_CODEUNIT *)((intptr_t)_PyCode_CODE(code) + (intptr_t)lasti);
+}
+
+static int get_frame_state(PyGenObject *gen_like) {
+    return gen_like->gi_frame_state;
+}
+
+static void set_frame_state(PyGenObject *gen_like, int fs) {
+    gen_like->gi_frame_state = (int8_t)fs;
+}
+
+static int valid_frame_state(int fs) {
+    return fs == FRAME_CREATED || fs == FRAME_SUSPENDED || fs == FRAME_EXECUTING || fs == FRAME_COMPLETED || fs == FRAME_CLEARED;
+}
+
+static int get_frame_stacktop_limit(Frame *frame) {
+    PyCodeObject *code = get_frame_code(frame);
+    return code->co_stacksize + code->co_nlocalsplus;
+}
+
+static int get_frame_stacktop(Frame *frame) {
+    int stacktop = frame->stacktop;
+    assert(stacktop >= 0 && stacktop < get_frame_stacktop_limit(frame));
+    return stacktop;
+}
+
+static void set_frame_stacktop(Frame *frame, int stacktop) {
+    assert(stacktop >= 0 && stacktop < get_frame_stacktop_limit(frame));
+    frame->stacktop = stacktop;
+}
+
+static PyObject **get_frame_localsplus(Frame *frame) {
+    PyObject **localsplus = frame->localsplus;
+    assert(localsplus);
+    return localsplus;
+}
+
+static int get_frame_iblock_limit(Frame *frame) {
+    return 1; // not applicable >= 3.11
+}
+
+static int get_frame_iblock(Frame *frame) {
+    return 0; // not applicable >= 3.11
+}
+
+static void set_frame_iblock(Frame *frame, int iblock) {
+    assert(!iblock); // not applicable >= 3.11
+}
+
+static PyTryBlock *get_frame_blockstack(Frame *frame) {
+    return NULL; // not applicable >= 3.11
+}

--- a/src/dispatch/experimental/durable/frame312.h
+++ b/src/dispatch/experimental/durable/frame312.h
@@ -1,0 +1,148 @@
+// This is a redefinition of the private/opaque frame object.
+//
+// https://github.com/python/cpython/blob/3.12/Include/internal/pycore_frame.h#L51
+//
+// In Python 3.10 and prior, `struct _frame` is both the PyFrameObject and
+// PyInterpreterFrame. From Python 3.11 onwards, the two were split with the
+// PyFrameObject (struct _frame) pointing to struct _PyInterpreterFrame.
+struct Frame {
+    PyCodeObject *f_code;
+    struct Frame *previous; // struct _PyInterpreterFrame
+    PyObject *f_funcobj;
+    PyObject *f_globals;
+    PyObject *f_builtins;
+    PyObject *f_locals;
+    PyFrameObject *frame_obj;
+    _Py_CODEUNIT *prev_instr;
+    int stacktop;
+    uint16_t return_offset;
+    char owner;
+    PyObject *localsplus[1];
+};
+
+// This is a redefinition of private frame state constants.
+// https://github.com/python/cpython/blob/3.12/Include/internal/pycore_frame.h#L34
+typedef enum _framestate {
+    FRAME_CREATED = -2,
+    FRAME_SUSPENDED = -1,
+    FRAME_EXECUTING = 0,
+    FRAME_COMPLETED = 1,
+    FRAME_CLEARED = 4
+} FrameState;
+
+/*
+// This is the definition of PyFrameObject (aka. struct _frame) for reference
+// to developers working on the extension.
+//
+// https://github.com/python/cpython/blob/3.12/Include/internal/pycore_frame.h#L16
+typedef struct {
+    PyObject_HEAD
+    PyFrameObject *f_back;
+    struct _PyInterpreterFrame *f_frame;
+    PyObject *f_trace;
+    int f_lineno;
+    char f_trace_lines;
+    char f_trace_opcodes;
+    char f_fast_as_locals;
+    PyObject *_f_frame_data[1];
+} PyFrameObject;
+*/
+
+/*
+// This is the definition of PyGenObject for reference to developers
+// working on the extension.
+//
+// Note that PyCoroObject and PyAsyncGenObject have the same layout as
+// PyGenObject, however the struct fields have a cr_ and ag_ prefix
+// (respectively) rather than a gi_ prefix.
+//
+// https://github.com/python/cpython/blob/3.12/Include/cpython/genobject.h#L14
+typedef struct {
+    PyObject_HEAD
+    PyObject *gi_weakreflist;
+    PyObject *gi_name;
+    PyObject *gi_qualname;
+    _PyErr_StackItem gi_exc_state;
+    PyObject *gi_origin_or_finalizer;
+    char gi_hooks_inited;
+    char gi_closed;
+    char gi_running_async;
+    int8_t gi_frame_state;
+    PyObject *gi_iframe[1];
+} PyGenObject;
+*/
+
+static Frame *get_frame(PyGenObject *gen_like) {
+    Frame *frame = (Frame *)(struct _PyInterpreterFrame *)(gen_like->gi_iframe);
+    assert(frame);
+    return frame;
+}
+
+static PyCodeObject *get_frame_code(Frame *frame) {
+    PyCodeObject *code = frame->f_code;
+    assert(code);
+    return code;
+}
+
+static int get_frame_lasti(Frame *frame) {
+    // https://github.com/python/cpython/blob/3.12/Include/internal/pycore_frame.h#L77
+    PyCodeObject *code = get_frame_code(frame);
+    assert(frame->prev_instr);
+    return (int)((intptr_t)frame->prev_instr - (intptr_t)_PyCode_CODE(code));
+}
+
+static void set_frame_lasti(Frame *frame, int lasti) {
+    // https://github.com/python/cpython/blob/3.12/Include/internal/pycore_frame.h#L77
+    PyCodeObject *code = get_frame_code(frame);
+    frame->prev_instr = (_Py_CODEUNIT *)((intptr_t)_PyCode_CODE(code) + (intptr_t)lasti);
+}
+
+static int get_frame_state(PyGenObject *gen_like) {
+    return gen_like->gi_frame_state;
+}
+
+static void set_frame_state(PyGenObject *gen_like, int fs) {
+    gen_like->gi_frame_state = (int8_t)fs;
+}
+
+static int valid_frame_state(int fs) {
+    return fs == FRAME_CREATED || fs == FRAME_SUSPENDED || fs == FRAME_EXECUTING || fs == FRAME_COMPLETED || fs == FRAME_CLEARED;
+}
+
+static int get_frame_stacktop_limit(Frame *frame) {
+    PyCodeObject *code = get_frame_code(frame);
+    return code->co_stacksize + code->co_nlocalsplus;
+}
+
+static int get_frame_stacktop(Frame *frame) {
+    int stacktop = frame->stacktop;
+    assert(stacktop >= 0 && stacktop < get_frame_stacktop_limit(frame));
+    return stacktop;
+}
+
+static void set_frame_stacktop(Frame *frame, int stacktop) {
+    assert(stacktop >= 0 && stacktop < get_frame_stacktop_limit(frame));
+    frame->stacktop = stacktop;
+}
+
+static PyObject **get_frame_localsplus(Frame *frame) {
+    PyObject **localsplus = frame->localsplus;
+    assert(localsplus);
+    return localsplus;
+}
+
+static int get_frame_iblock_limit(Frame *frame) {
+    return 1; // not applicable >= 3.11
+}
+
+static int get_frame_iblock(Frame *frame) {
+    return 0; // not applicable >= 3.11
+}
+
+static void set_frame_iblock(Frame *frame, int iblock) {
+    assert(!iblock); // not applicable >= 3.11
+}
+
+static PyTryBlock *get_frame_blockstack(Frame *frame) {
+    return NULL; // not applicable >= 3.11
+}

--- a/src/dispatch/experimental/durable/frame313.h
+++ b/src/dispatch/experimental/durable/frame313.h
@@ -1,0 +1,148 @@
+// This is a redefinition of the private/opaque frame object.
+// https://github.com/python/cpython/blob/v3.13.0a5/Include/internal/pycore_frame.h#L57
+//
+// In Python 3.10 and prior, `struct _frame` is both the PyFrameObject and
+// PyInterpreterFrame. From Python 3.11 onwards, the two were split with the
+// PyFrameObject (struct _frame) pointing to struct _PyInterpreterFrame.
+struct Frame {
+    PyObject *f_executable;
+    struct Frame *previous; // struct _PyInterpreterFrame
+    PyObject *f_funcobj;
+    PyObject *f_globals;
+    PyObject *f_builtins;
+    PyObject *f_locals;
+    PyFrameObject *frame_obj;
+    _Py_CODEUNIT *instr_ptr;
+    int stacktop;
+    uint16_t return_offset;
+    char owner;
+    PyObject *localsplus[1];
+};
+
+// This is a redefinition of private frame state constants.
+// https://github.com/python/cpython/blob/v3.13.0a5/Include/internal/pycore_frame.h#L38
+typedef enum _framestate {
+    FRAME_CREATED = -3,
+    FRAME_SUSPENDED = -2,
+    FRAME_SUSPENDED_YIELD_FROM = -1,
+    FRAME_EXECUTING = 0,
+    FRAME_COMPLETED = 1,
+    FRAME_CLEARED = 4
+} FrameState;
+
+/*
+// This is the definition of PyFrameObject (aka. struct _frame) for reference
+// to developers working on the extension.
+//
+// https://github.com/python/cpython/blob/v3.13.0a5/Include/internal/pycore_frame.h#L20
+typedef struct {
+    PyObject_HEAD
+    PyFrameObject *f_back;
+    struct _PyInterpreterFrame *f_frame;
+    PyObject *f_trace;
+    int f_lineno;
+    char f_trace_lines;
+    char f_trace_opcodes;
+    char f_fast_as_locals;
+    PyObject *_f_frame_data[1];
+} PyFrameObject;
+*/
+
+/*
+// This is the definition of PyGenObject for reference to developers
+// working on the extension.
+//
+// Note that PyCoroObject and PyAsyncGenObject have the same layout as
+// PyGenObject, however the struct fields have a cr_ and ag_ prefix
+// (respectively) rather than a gi_ prefix.
+//
+// https://github.com/python/cpython/blob/v3.13.0a5/Include/cpython/genobject.h#L14
+typedef struct {
+    PyObject_HEAD
+    PyObject *gi_weakreflist;
+    PyObject *gi_name;
+    PyObject *gi_qualname;
+    _PyErr_StackItem gi_exc_state;
+    PyObject *gi_origin_or_finalizer;
+    char gi_hooks_inited;
+    char gi_closed;
+    char gi_running_async;
+    int8_t gi_frame_state;
+    PyObject *gi_iframe[1];
+} PyGenObject;
+*/
+
+static Frame *get_frame(PyGenObject *gen_like) {
+    Frame *frame = (Frame *)(struct _PyInterpreterFrame *)(gen_like->gi_iframe);
+    assert(frame);
+    return frame;
+}
+
+static PyCodeObject *get_frame_code(Frame *frame) {
+    PyCodeObject *code = (PyCodeObject *)frame->f_executable;
+    assert(code);
+    return code;
+}
+
+static int get_frame_lasti(Frame *frame) {
+    // https://github.com/python/cpython/blob/v3.13.0a5/Include/internal/pycore_frame.h#L73
+    PyCodeObject *code = get_frame_code(frame);
+    assert(frame->instr_ptr);
+    return (int)((intptr_t)frame->instr_ptr - (intptr_t)_PyCode_CODE(code));
+}
+
+static void set_frame_lasti(Frame *frame, int lasti) {
+    // https://github.com/python/cpython/blob/v3.13.0a5/Include/internal/pycore_frame.h#L73
+    PyCodeObject *code = get_frame_code(frame);
+    frame->instr_ptr = (_Py_CODEUNIT *)((intptr_t)_PyCode_CODE(code) + (intptr_t)lasti);
+}
+
+static int get_frame_state(PyGenObject *gen_like) {
+    return gen_like->gi_frame_state;
+}
+
+static void set_frame_state(PyGenObject *gen_like, int fs) {
+    gen_like->gi_frame_state = (int8_t)fs;
+}
+
+static int valid_frame_state(int fs) {
+    return fs == FRAME_CREATED || fs == FRAME_SUSPENDED || fs == FRAME_SUSPENDED_YIELD_FROM || fs == FRAME_EXECUTING || fs == FRAME_COMPLETED || fs == FRAME_CLEARED;
+}
+
+static int get_frame_stacktop_limit(Frame *frame) {
+    PyCodeObject *code = get_frame_code(frame);
+    return code->co_stacksize + code->co_nlocalsplus;
+}
+
+static int get_frame_stacktop(Frame *frame) {
+    int stacktop = frame->stacktop;
+    assert(stacktop >= 0 && stacktop < get_frame_stacktop_limit(frame));
+    return stacktop;
+}
+
+static void set_frame_stacktop(Frame *frame, int stacktop) {
+    assert(stacktop >= 0 && stacktop < get_frame_stacktop_limit(frame));
+    frame->stacktop = stacktop;
+}
+
+static PyObject **get_frame_localsplus(Frame *frame) {
+    PyObject **localsplus = frame->localsplus;
+    assert(localsplus);
+    return localsplus;
+}
+
+static int get_frame_iblock_limit(Frame *frame) {
+    return 1; // not applicable >= 3.11
+}
+
+static int get_frame_iblock(Frame *frame) {
+    return 0; // not applicable >= 3.11
+}
+
+static void set_frame_iblock(Frame *frame, int iblock) {
+    assert(!iblock); // not applicable >= 3.11
+}
+
+static PyTryBlock *get_frame_blockstack(Frame *frame) {
+    return NULL; // not applicable >= 3.11
+}

--- a/src/dispatch/experimental/durable/function.py
+++ b/src/dispatch/experimental/durable/function.py
@@ -110,9 +110,10 @@ class Serializable:
             ip = ext.get_frame_ip(g)
             sp = ext.get_frame_sp(g)
             bp = ext.get_frame_bp(g)
-            stack = [ext.get_frame_stack_at(g, i) for i in range(ext.get_frame_sp(g))]
+            stack = [ext.get_frame_stack_at(g, i) for i in range(sp)]
+            blocks = [ext.get_frame_block_at(g, i) for i in range(bp)]
         else:
-            ip, sp, bp, stack = None, None, None, None
+            ip, sp, bp, stack, blocks = None, None, None, None, None
 
         if TRACE:
             print(f"\n[DISPATCH] Serializing {self}:")
@@ -125,12 +126,14 @@ class Serializable:
             if frame_state < FRAME_CLEARED:
                 print(f"IP = {ip}")
                 print(f"SP = {sp}")
-                print(f"BP = {bp}")
                 for i, (is_null, value) in enumerate(stack):
                     if is_null:
                         print(f"stack[{i}] = NULL")
                     else:
                         print(f"stack[{i}] = {value}")
+                print(f"BP = {bp}")
+                for i, block in enumerate(blocks):
+                    print(f"block[{i}] = {block}")
             print()
 
         state = {
@@ -148,6 +151,7 @@ class Serializable:
                 "sp": sp,
                 "bp": bp,
                 "stack": stack,
+                "blocks": blocks,
                 "state": frame_state,
             },
         }
@@ -188,9 +192,11 @@ class Serializable:
             # Restore the frame.
             ext.set_frame_ip(g, frame_state["ip"])
             ext.set_frame_sp(g, frame_state["sp"])
-            ext.set_frame_bp(g, frame_state["bp"])
             for i, (is_null, obj) in enumerate(frame_state["stack"]):
                 ext.set_frame_stack_at(g, i, is_null, obj)
+            ext.set_frame_bp(g, frame_state["bp"])
+            for i, block in enumerate(frame_state["blocks"]):
+                ext.set_frame_block_at(g, i, block)
             ext.set_frame_state(g, frame_state["state"])
         else:
             g = None

--- a/src/dispatch/experimental/durable/function.py
+++ b/src/dispatch/experimental/durable/function.py
@@ -249,7 +249,7 @@ class DurableCoroutine(Serializable, Coroutine[_YieldT, _SendT, _ReturnT]):
 
     @property
     def cr_suspended(self) -> bool:
-        return self.coroutine.cr_suspended
+        return getattr(self.coroutine, "cr_suspended", False)
 
     @property
     def cr_code(self) -> CodeType:
@@ -315,7 +315,7 @@ class DurableGenerator(Serializable, Generator[_YieldT, _SendT, _ReturnT]):
 
     @property
     def gi_suspended(self) -> bool:
-        return self.generator.gi_suspended
+        return getattr(self.generator, "gi_suspended", False)
 
     @property
     def gi_code(self) -> CodeType:

--- a/src/dispatch/experimental/durable/function.py
+++ b/src/dispatch/experimental/durable/function.py
@@ -109,9 +109,10 @@ class Serializable:
         if frame_state < FRAME_CLEARED:
             ip = ext.get_frame_ip(g)
             sp = ext.get_frame_sp(g)
+            bp = ext.get_frame_bp(g)
             stack = [ext.get_frame_stack_at(g, i) for i in range(ext.get_frame_sp(g))]
         else:
-            ip, sp, stack = None, None, None
+            ip, sp, bp, stack = None, None, None, None
 
         if TRACE:
             print(f"\n[DISPATCH] Serializing {self}:")
@@ -124,6 +125,7 @@ class Serializable:
             if frame_state < FRAME_CLEARED:
                 print(f"IP = {ip}")
                 print(f"SP = {sp}")
+                print(f"BP = {bp}")
                 for i, (is_null, value) in enumerate(stack):
                     if is_null:
                         print(f"stack[{i}] = NULL")
@@ -144,6 +146,7 @@ class Serializable:
             "frame": {
                 "ip": ip,
                 "sp": sp,
+                "bp": bp,
                 "stack": stack,
                 "state": frame_state,
             },
@@ -182,9 +185,10 @@ class Serializable:
             else:
                 g = rfn.fn(*args, **kwargs)
 
-            # Restore the frame state (stack + stack pointer + instruction pointer).
+            # Restore the frame.
             ext.set_frame_ip(g, frame_state["ip"])
             ext.set_frame_sp(g, frame_state["sp"])
+            ext.set_frame_bp(g, frame_state["bp"])
             for i, (is_null, obj) in enumerate(frame_state["stack"]):
                 ext.set_frame_stack_at(g, i, is_null, obj)
             ext.set_frame_state(g, frame_state["state"])

--- a/tests/dispatch/experimental/durable/test_coroutine.py
+++ b/tests/dispatch/experimental/durable/test_coroutine.py
@@ -97,7 +97,10 @@ class TestCoroutine(unittest.TestCase):
 
         def check():
             self.assertEqual(c.cr_running, underlying.cr_running)
-            self.assertEqual(c.cr_suspended, underlying.cr_suspended)
+            try:
+                self.assertEqual(c.cr_suspended, underlying.cr_suspended)
+            except AttributeError:
+                pass
             self.assertEqual(c.cr_origin, underlying.cr_origin)
             self.assertIs(c.cr_await, underlying.cr_await)
 

--- a/tests/dispatch/experimental/durable/test_generator.py
+++ b/tests/dispatch/experimental/durable/test_generator.py
@@ -99,7 +99,10 @@ class TestGenerator(unittest.TestCase):
 
         def check():
             self.assertEqual(g.gi_running, underlying.gi_running)
-            self.assertEqual(g.gi_suspended, underlying.gi_suspended)
+            try:
+                self.assertEqual(g.gi_suspended, underlying.gi_suspended)
+            except AttributeError:
+                pass
             self.assertIs(g.gi_yieldfrom, underlying.gi_yieldfrom)
 
         check()


### PR DESCRIPTION
This PR adds support for Python 3.10.

Versions prior to 3.11 have an additional stack of "blocks" on each frame that need to be persisted. We now store this information along with a "block pointer" so that we can later restore the frame properly. 

In https://github.com/stealthrocket/dispatch-py/pull/136/commits/703f1e8c21c5bf86d569ee15af137d4297a6d2e2, I changed the extension so that it's more verbose when it comes to handling the differences across Python versions. Previously we were using macros with range checks, and aliasing fields that had the same structure but used different names across versions. Given the divergence in frame structures across Python 3.10 and 3.11, I felt it was better to be explicit and verbose when dealing with differences across versions. There'll now be a block of `#if PY_MINOR_VERSION == N ... #elif PY_MINOR_VERSION == N+1 ... #elif PY_MINOR_VERSION == N+2 ... #endif` each time something changes across versions, and there'll be a block for each version that we support. This should make it easier to add support for more versions (e.g. 3.9) and also deprecate versions in future.

This fixes #42.