### PR TITLE
Promote httpx dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,8 @@ dependencies = [
     "http-message-signatures >= 0.4.4",
     "tblib >= 3.0.0",
     "docopt >= 0.6.2",
-    "types-docopt >= 0.6.11.4"
+    "types-docopt >= 0.6.11.4",
+    "httpx >= 0.27.0"
 ]
 
 [project.optional-dependencies]
@@ -28,7 +29,6 @@ dev = [
     "mypy >= 1.8.0",
     "pytest==8.0.0",
     "fastapi >= 0.109.0",
-    "httpx >= 0.26.0",
     "coverage >= 7.4.1",
     "requests >= 2.31.0",
     "types-requests >= 2.31.0.20240125",


### PR DESCRIPTION
Same issue as https://github.com/stealthrocket/dispatch-py/pull/130. The `dispatch.test` package relies on `httpx` to make requests to the endpoint. The package and `python -m dispatch.test` command don't work if `httpx` is only a dev dependency.