### PR TITLE
Minor UX improvements

### DIFF
--- a/src/dispatch/fastapi.py
+++ b/src/dispatch/fastapi.py
@@ -120,11 +120,6 @@ class Dispatch(Registry):
         function_service = _new_app(self, verification_key)
         app.mount("/dispatch.sdk.v1.FunctionService", function_service)
 
-    def batch(self) -> Batch:
-        """Returns a Batch instance that can be used to build
-        a set of calls to dispatch."""
-        return self.client.batch()
-
 
 def parse_verification_key(
     verification_key: Ed25519PublicKey | str | bytes | None,

--- a/src/dispatch/function.py
+++ b/src/dispatch/function.py
@@ -250,6 +250,11 @@ class Registry:
         for fn in self.functions.values():
             fn._client = client
 
+    def batch(self) -> Batch:
+        """Returns a Batch instance that can be used to build
+        a set of calls to dispatch."""
+        return self.client.batch()
+
 
 class Client:
     """Client for the Dispatch API."""

--- a/src/dispatch/test/__main__.py
+++ b/src/dispatch/test/__main__.py
@@ -85,7 +85,11 @@ def main():
             print(f'  export DISPATCH_VERIFICATION_KEY="{verification_key}"')
             print()
 
-            server.wait()
+            try:
+                server.wait()
+            except KeyboardInterrupt:
+                print("closing down server after interrupt")
+                pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Two improvements I noticed:
* I moved the `batch` helper from `dispatch.fastapi.Dispatch` to the `dispatch.function.Registry` base class, so that it can be used when you construct a remote endpoint registry (#134)
* when quitting the `python -m dispatch.test` server with SIGINT / Ctrl+C, previously it would print a stack trace from where the `KeyboardInterrupt` was raised. Now it prints a nice single-line exit message
 