### PR TITLE
Python 3.9 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.10', '3.11', '3.12']
+        python: ['3.9', '3.10', '3.11', '3.12']
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,8 @@ dependencies = [
     "tblib >= 3.0.0",
     "docopt >= 0.6.2",
     "types-docopt >= 0.6.11.4",
-    "httpx >= 0.27.0"
+    "httpx >= 0.27.0",
+    "typing_extensions >= 4.10"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "dispatch-py"
 description = "Develop reliable distributed systems on the Dispatch platform."
 readme = "README.md"
 dynamic = ["version"]
-requires-python = ">= 3.10"
+requires-python = ">= 3.9"
 dependencies = [
     "grpcio >= 1.60.0",
     "protobuf >= 4.24.0",

--- a/src/dispatch/coroutine.py
+++ b/src/dispatch/coroutine.py
@@ -48,17 +48,17 @@ def race(*awaitables: Awaitable[Any]) -> list[Any]:  # type: ignore[misc]
     return (yield RaceDirective(awaitables))
 
 
-@dataclass(slots=True)
+@dataclass
 class AllDirective:
     awaitables: tuple[Awaitable[Any], ...]
 
 
-@dataclass(slots=True)
+@dataclass
 class AnyDirective:
     awaitables: tuple[Awaitable[Any], ...]
 
 
-@dataclass(slots=True)
+@dataclass
 class RaceDirective:
     awaitables: tuple[Awaitable[Any], ...]
 

--- a/src/dispatch/experimental/durable/frame.pyi
+++ b/src/dispatch/experimental/durable/frame.pyi
@@ -1,31 +1,31 @@
 from types import FrameType
-from typing import Any, AsyncGenerator, Coroutine, Generator, Tuple
+from typing import Any, AsyncGenerator, Coroutine, Generator, Tuple, Union
 
-def get_frame_ip(frame: FrameType | Coroutine | Generator | AsyncGenerator) -> int:
+def get_frame_ip(frame: Union[FrameType, Coroutine, Generator, AsyncGenerator]) -> int:
     """Get instruction pointer of a generator or coroutine."""
 
-def set_frame_ip(frame: FrameType | Coroutine | Generator | AsyncGenerator, ip: int):
+def set_frame_ip(frame: Union[FrameType, Coroutine, Generator, AsyncGenerator], ip: int):
     """Set instruction pointer of a generator or coroutine."""
 
-def get_frame_sp(frame: FrameType | Coroutine | Generator | AsyncGenerator) -> int:
+def get_frame_sp(frame: Union[FrameType, Coroutine, Generator, AsyncGenerator]) -> int:
     """Get stack pointer of a generator or coroutine."""
 
-def set_frame_sp(frame: FrameType | Coroutine | Generator | AsyncGenerator, sp: int):
+def set_frame_sp(frame: Union[FrameType, Coroutine, Generator, AsyncGenerator], sp: int):
     """Set stack pointer of a generator or coroutine."""
 
-def get_frame_bp(frame: FrameType | Coroutine | Generator | AsyncGenerator) -> int:
+def get_frame_bp(frame: Union[FrameType, Coroutine, Generator, AsyncGenerator]) -> int:
     """Get block pointer of a generator or coroutine."""
 
-def set_frame_bp(frame: FrameType | Coroutine | Generator | AsyncGenerator, bp: int):
+def set_frame_bp(frame: Union[FrameType, Coroutine, Generator, AsyncGenerator], bp: int):
     """Set block pointer of a generator or coroutine."""
 
 def get_frame_stack_at(
-    frame: FrameType | Coroutine | Generator | AsyncGenerator, index: int
+    frame: Union[FrameType, Coroutine, Generator, AsyncGenerator], index: int
 ) -> Tuple[bool, Any]:
     """Get an object from a generator or coroutine's stack, as an (is_null, obj) tuple."""
 
 def set_frame_stack_at(
-    frame: FrameType | Coroutine | Generator | AsyncGenerator,
+    frame: Union[FrameType, Coroutine, Generator, AsyncGenerator],
     index: int,
     unset: bool,
     value: Any,
@@ -33,23 +33,23 @@ def set_frame_stack_at(
     """Set or unset an object on the stack of a generator or coroutine."""
 
 def get_frame_block_at(
-    frame: FrameType | Coroutine | Generator | AsyncGenerator, index: int
+    frame: Union[FrameType, Coroutine, Generator, AsyncGenerator], index: int
 ) -> Tuple[int, int, int]:
     """Get a block from a generator or coroutine."""
 
 def set_frame_block_at(
-    frame: FrameType | Coroutine | Generator | AsyncGenerator,
+    frame: Union[FrameType, Coroutine, Generator, AsyncGenerator],
     index: int,
     value: Tuple[int, int, int],
 ):
     """Restore a block of a generator or coroutine."""
 
 def get_frame_state(
-    frame: FrameType | Coroutine | Generator | AsyncGenerator,
+    frame: Union[FrameType, Coroutine, Generator, AsyncGenerator],
 ) -> int:
     """Get frame state of a generator or coroutine."""
 
 def set_frame_state(
-    frame: FrameType | Coroutine | Generator | AsyncGenerator, state: int
+    frame: Union[FrameType, Coroutine, Generator, AsyncGenerator], state: int
 ):
     """Set frame state of a generator or coroutine."""

--- a/src/dispatch/experimental/durable/frame.pyi
+++ b/src/dispatch/experimental/durable/frame.pyi
@@ -4,19 +4,25 @@ from typing import Any, AsyncGenerator, Coroutine, Generator, Tuple, Union
 def get_frame_ip(frame: Union[FrameType, Coroutine, Generator, AsyncGenerator]) -> int:
     """Get instruction pointer of a generator or coroutine."""
 
-def set_frame_ip(frame: Union[FrameType, Coroutine, Generator, AsyncGenerator], ip: int):
+def set_frame_ip(
+    frame: Union[FrameType, Coroutine, Generator, AsyncGenerator], ip: int
+):
     """Set instruction pointer of a generator or coroutine."""
 
 def get_frame_sp(frame: Union[FrameType, Coroutine, Generator, AsyncGenerator]) -> int:
     """Get stack pointer of a generator or coroutine."""
 
-def set_frame_sp(frame: Union[FrameType, Coroutine, Generator, AsyncGenerator], sp: int):
+def set_frame_sp(
+    frame: Union[FrameType, Coroutine, Generator, AsyncGenerator], sp: int
+):
     """Set stack pointer of a generator or coroutine."""
 
 def get_frame_bp(frame: Union[FrameType, Coroutine, Generator, AsyncGenerator]) -> int:
     """Get block pointer of a generator or coroutine."""
 
-def set_frame_bp(frame: Union[FrameType, Coroutine, Generator, AsyncGenerator], bp: int):
+def set_frame_bp(
+    frame: Union[FrameType, Coroutine, Generator, AsyncGenerator], bp: int
+):
     """Set block pointer of a generator or coroutine."""
 
 def get_frame_stack_at(

--- a/src/dispatch/experimental/durable/frame309.h
+++ b/src/dispatch/experimental/durable/frame309.h
@@ -1,0 +1,144 @@
+// This is a redefinition of the private/opaque frame object.
+// https://github.com/python/cpython/blob/3.9/Include/cpython/frameobject.h#L17
+//
+// In Python <= 3.10, `struct _frame` is both the PyFrameObject and
+// PyInterpreterFrame. From Python 3.11 onwards, the two were split with the
+// PyFrameObject (struct _frame) pointing to struct _PyInterpreterFrame.
+struct Frame {
+    PyObject_VAR_HEAD
+    struct Frame *f_back; // struct _frame
+    PyCodeObject *f_code;
+    PyObject *f_builtins;
+    PyObject *f_globals;
+    PyObject *f_locals;
+    PyObject **f_valuestack;
+    PyObject **f_stacktop;
+    PyObject *f_trace;
+    char f_trace_lines;
+    char f_trace_opcodes;
+    PyObject *f_gen;
+    int f_lasti;
+    int f_lineno;
+    int f_iblock;
+    char f_executing;
+    PyTryBlock f_blockstack[CO_MAXBLOCKS];
+    PyObject *f_localsplus[1];
+};
+
+// Python 3.9 and prior didn't have an explicit enum of frame states,
+// but we can derive them based on the presence of a frame, and other
+// information found on the frame, for compatibility with later versions.
+typedef enum _framestate {
+    FRAME_CREATED = -2,
+    FRAME_EXECUTING = 0,
+    FRAME_CLEARED = 4
+} FrameState;
+
+/*
+// This is the definition of PyGenObject for reference to developers
+// working on the extension.
+//
+// Note that PyCoroObject and PyAsyncGenObject have the same layout as
+// PyGenObject, however the struct fields have a cr_ and ag_ prefix
+// (respectively) rather than a gi_ prefix. In Python <= 3.10, PyCoroObject
+// and PyAsyncGenObject have extra fields compared to PyGenObject. In Python
+// 3.11 onwards, the three objects are identical (except for field name
+// prefixes). The extra fields in Python <= 3.10 are not applicable to the
+// extension at this time.
+//
+// https://github.com/python/cpython/blob/3.9/Include/genobject.h#L15
+typedef struct {
+    PyObject_HEAD
+    PyFrameObject *gi_frame;
+    char gi_running;
+    PyObject *gi_code;
+    PyObject *gi_weakreflist;
+    PyObject *gi_name;
+    PyObject *gi_qualname;
+    _PyErr_StackItem gi_exc_state;
+} PyGenObject;
+*/
+
+static Frame *get_frame(PyGenObject *gen_like) {
+    Frame *frame = (Frame *)(gen_like->gi_frame);
+    assert(frame);
+    return frame;
+}
+
+static PyCodeObject *get_frame_code(Frame *frame) {
+    PyCodeObject *code = frame->f_code;
+    assert(code);
+    return code;
+}
+
+static int get_frame_lasti(Frame *frame) {
+    return frame->f_lasti;
+}
+
+static void set_frame_lasti(Frame *frame, int lasti) {
+    frame->f_lasti = lasti;
+}
+
+static int get_frame_state(PyGenObject *gen_like) {
+    // Python 3.9 doesn't have frame states, but we can derive
+    // some for compatibility with later versions and to simplify
+    // the extension.
+    Frame *frame = (Frame *)(gen_like->gi_frame);
+    if (!frame) {
+        return FRAME_CLEARED;
+    }
+    return frame->f_executing ? FRAME_EXECUTING : FRAME_CREATED;
+}
+
+static void set_frame_state(PyGenObject *gen_like, int fs) {
+    Frame *frame = get_frame(gen_like);
+    frame->f_executing = (fs == FRAME_EXECUTING);
+}
+
+static int valid_frame_state(int fs) {
+    return fs == FRAME_CREATED || fs == FRAME_EXECUTING || fs == FRAME_CLEARED;
+}
+
+static int get_frame_stacktop_limit(Frame *frame) {
+    PyCodeObject *code = get_frame_code(frame);
+    return code->co_stacksize + code->co_nlocals;
+}
+
+static int get_frame_stacktop(Frame *frame) {
+    assert(frame->f_localsplus);
+    int stacktop = (int)(frame->f_stacktop - frame->f_localsplus);
+    assert(stacktop >= 0 && stacktop < get_frame_stacktop_limit(frame));
+    return stacktop;
+}
+
+static void set_frame_stacktop(Frame *frame, int stacktop) {
+    assert(stacktop >= 0 && stacktop < get_frame_stacktop_limit(frame));
+    assert(frame->f_localsplus);
+    frame->f_stacktop = frame->f_localsplus + stacktop;
+}
+
+static PyObject **get_frame_localsplus(Frame *frame) {
+    PyObject **localsplus = frame->f_localsplus;
+    assert(localsplus);
+    return localsplus;
+}
+
+static int get_frame_iblock_limit(Frame *frame) {
+    return CO_MAXBLOCKS;
+}
+
+static int get_frame_iblock(Frame *frame) {
+    return frame->f_iblock;
+}
+
+static void set_frame_iblock(Frame *frame, int iblock) {
+    assert(iblock >= 0 && iblock < get_frame_iblock_limit(frame));
+    frame->f_iblock = iblock;
+}
+
+static PyTryBlock *get_frame_blockstack(Frame *frame) {
+    PyTryBlock *blockstack = frame->f_blockstack;
+    assert(blockstack);
+    return blockstack;
+}
+

--- a/src/dispatch/experimental/durable/function.py
+++ b/src/dispatch/experimental/durable/function.py
@@ -9,7 +9,7 @@ from types import (
     MethodType,
     TracebackType,
 )
-from typing import Any, Callable, Coroutine, Generator, TypeVar, Union, cast, Optional
+from typing import Any, Callable, Coroutine, Generator, Optional, TypeVar, Union, cast
 
 from . import frame as ext
 from .registry import RegisteredFunction, lookup_function, register_function

--- a/src/dispatch/experimental/durable/function.py
+++ b/src/dispatch/experimental/durable/function.py
@@ -9,7 +9,7 @@ from types import (
     MethodType,
     TracebackType,
 )
-from typing import Any, Callable, Coroutine, Generator, TypeVar, Union, cast
+from typing import Any, Callable, Coroutine, Generator, TypeVar, Union, cast, Optional
 
 from . import frame as ext
 from .registry import RegisteredFunction, lookup_function, register_function
@@ -75,7 +75,7 @@ class Serializable:
         "__qualname__",
     )
 
-    g: GeneratorType | CoroutineType
+    g: Union[GeneratorType, CoroutineType]
     registered_fn: RegisteredFunction
     wrapped_coroutine: Union["DurableCoroutine", None]
     args: tuple[Any, ...]
@@ -83,7 +83,7 @@ class Serializable:
 
     def __init__(
         self,
-        g: GeneratorType | CoroutineType,
+        g: Union[GeneratorType, CoroutineType],
         registered_fn: RegisteredFunction,
         wrapped_coroutine: Union["DurableCoroutine", None],
         *args: Any,
@@ -243,7 +243,7 @@ class DurableCoroutine(Serializable, Coroutine[_YieldT, _SendT, _ReturnT]):
     def send(self, send: _SendT) -> _YieldT:
         return self.coroutine.send(send)
 
-    def throw(self, typ, val=None, tb: TracebackType | None = None) -> _YieldT:
+    def throw(self, typ, val=None, tb: Optional[TracebackType] = None) -> _YieldT:
         return self.coroutine.throw(typ, val, tb)
 
     def close(self) -> None:
@@ -270,11 +270,11 @@ class DurableCoroutine(Serializable, Coroutine[_YieldT, _SendT, _ReturnT]):
         return self.coroutine.cr_frame
 
     @property
-    def cr_await(self) -> Any | None:
+    def cr_await(self) -> Any:
         return self.coroutine.cr_await
 
     @property
-    def cr_origin(self) -> tuple[tuple[str, int, str], ...] | None:
+    def cr_origin(self) -> Optional[tuple[tuple[str, int, str], ...]]:
         return self.coroutine.cr_origin
 
     def __repr__(self) -> str:
@@ -291,7 +291,7 @@ class DurableGenerator(Serializable, Generator[_YieldT, _SendT, _ReturnT]):
         self,
         generator: GeneratorType,
         registered_fn: RegisteredFunction,
-        coroutine: DurableCoroutine | None,
+        coroutine: Optional[DurableCoroutine],
         *args: Any,
         **kwargs: Any,
     ):
@@ -309,7 +309,7 @@ class DurableGenerator(Serializable, Generator[_YieldT, _SendT, _ReturnT]):
     def send(self, send: _SendT) -> _YieldT:
         return self.generator.send(send)
 
-    def throw(self, typ, val=None, tb: TracebackType | None = None) -> _YieldT:
+    def throw(self, typ, val=None, tb: Optional[TracebackType] = None) -> _YieldT:
         return self.generator.throw(typ, val, tb)
 
     def close(self) -> None:
@@ -336,7 +336,7 @@ class DurableGenerator(Serializable, Generator[_YieldT, _SendT, _ReturnT]):
         return self.generator.gi_frame
 
     @property
-    def gi_yieldfrom(self) -> GeneratorType | None:
+    def gi_yieldfrom(self) -> Optional[GeneratorType]:
         return self.generator.gi_yieldfrom
 
     def __repr__(self) -> str:

--- a/src/dispatch/experimental/durable/registry.py
+++ b/src/dispatch/experimental/durable/registry.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from types import FunctionType
 
 
-@dataclass(slots=True)
+@dataclass
 class RegisteredFunction:
     """A function that can be referenced in durable state."""
 

--- a/src/dispatch/fastapi.py
+++ b/src/dispatch/fastapi.py
@@ -21,8 +21,8 @@ import base64
 import logging
 import os
 from datetime import timedelta
-from urllib.parse import urlparse
 from typing import Optional, Union
+from urllib.parse import urlparse
 
 import fastapi
 import fastapi.responses

--- a/src/dispatch/fastapi.py
+++ b/src/dispatch/fastapi.py
@@ -22,6 +22,7 @@ import logging
 import os
 from datetime import timedelta
 from urllib.parse import urlparse
+from typing import Optional, Union
 
 import fastapi
 import fastapi.responses
@@ -51,10 +52,10 @@ class Dispatch(Registry):
     def __init__(
         self,
         app: fastapi.FastAPI,
-        endpoint: str | None = None,
-        verification_key: Ed25519PublicKey | str | bytes | None = None,
-        api_key: str | None = None,
-        api_url: str | None = None,
+        endpoint: Optional[str] = None,
+        verification_key: Optional[Union[Ed25519PublicKey, str, bytes]] = None,
+        api_key: Optional[str] = None,
+        api_url: Optional[str] = None,
     ):
         """Initialize a Dispatch endpoint, and integrate it into a FastAPI app.
 
@@ -122,8 +123,8 @@ class Dispatch(Registry):
 
 
 def parse_verification_key(
-    verification_key: Ed25519PublicKey | str | bytes | None,
-) -> Ed25519PublicKey | None:
+    verification_key: Optional[Union[Ed25519PublicKey, str, bytes]],
+) -> Optional[Ed25519PublicKey]:
     if isinstance(verification_key, Ed25519PublicKey):
         return verification_key
 
@@ -169,7 +170,7 @@ class _ConnectError(fastapi.HTTPException):
         self.message = message
 
 
-def _new_app(function_registry: Dispatch, verification_key: Ed25519PublicKey | None):
+def _new_app(function_registry: Dispatch, verification_key: Optional[Ed25519PublicKey]):
     app = fastapi.FastAPI()
 
     @app.exception_handler(_ConnectError)

--- a/src/dispatch/function.py
+++ b/src/dispatch/function.py
@@ -12,14 +12,14 @@ from typing import (
     Dict,
     Generic,
     Iterable,
-    TypeVar,
     Optional,
+    TypeVar,
     overload,
 )
-from typing_extensions import ParamSpec, TypeAlias
 from urllib.parse import urlparse
 
 import grpc
+from typing_extensions import ParamSpec, TypeAlias
 
 import dispatch.coroutine
 import dispatch.sdk.v1.dispatch_pb2 as dispatch_pb
@@ -162,7 +162,10 @@ class Registry:
     __slots__ = ("functions", "endpoint", "client")
 
     def __init__(
-        self, endpoint: str, api_key: Optional[str] = None, api_url: Optional[str] = None
+        self,
+        endpoint: str,
+        api_key: Optional[str] = None,
+        api_url: Optional[str] = None,
     ):
         """Initialize a function registry.
 

--- a/src/dispatch/function.py
+++ b/src/dispatch/function.py
@@ -12,11 +12,11 @@ from typing import (
     Dict,
     Generic,
     Iterable,
-    ParamSpec,
-    TypeAlias,
     TypeVar,
+    Optional,
     overload,
 )
+from typing_extensions import ParamSpec, TypeAlias
 from urllib.parse import urlparse
 
 import grpc
@@ -73,7 +73,7 @@ class PrimitiveFunction:
         return dispatch_id
 
     def _build_primitive_call(
-        self, input: Any, correlation_id: int | None = None
+        self, input: Any, correlation_id: Optional[int] = None
     ) -> Call:
         return Call(
             correlation_id=correlation_id,
@@ -137,7 +137,7 @@ class Function(PrimitiveFunction, Generic[P, T]):
         return self._primitive_dispatch(Arguments(args, kwargs))
 
     def build_call(
-        self, *args: P.args, correlation_id: int | None = None, **kwargs: P.kwargs
+        self, *args: P.args, correlation_id: Optional[int] = None, **kwargs: P.kwargs
     ) -> Call:
         """Create a Call for this function with the provided input. Useful to
         generate calls when using the Client.
@@ -162,7 +162,7 @@ class Registry:
     __slots__ = ("functions", "endpoint", "client")
 
     def __init__(
-        self, endpoint: str, api_key: str | None = None, api_url: str | None = None
+        self, endpoint: str, api_key: Optional[str] = None, api_url: Optional[str] = None
     ):
         """Initialize a function registry.
 
@@ -261,7 +261,7 @@ class Client:
 
     __slots__ = ("api_url", "api_key", "_stub", "api_key_from")
 
-    def __init__(self, api_key: None | str = None, api_url: None | str = None):
+    def __init__(self, api_key: Optional[str] = None, api_url: Optional[str] = None):
         """Create a new Dispatch client.
 
         Args:

--- a/src/dispatch/id.py
+++ b/src/dispatch/id.py
@@ -1,4 +1,4 @@
-from typing import TypeAlias
+from typing_extensions import TypeAlias
 
 DispatchID: TypeAlias = str
 """Unique identifier in Dispatch.

--- a/src/dispatch/integrations/http.py
+++ b/src/dispatch/integrations/http.py
@@ -4,33 +4,31 @@ from dispatch.status import Status
 def http_response_code_status(code: int) -> Status:
     """Returns a Status that's broadly equivalent to an HTTP response
     status code."""
-    match code:
-        case 400:  # Bad Request
-            return Status.INVALID_ARGUMENT
-        case 401:  # Unauthorized
-            return Status.UNAUTHENTICATED
-        case 403:  # Forbidden
-            return Status.PERMISSION_DENIED
-        case 404:  # Not Found
-            return Status.NOT_FOUND
-        case 408:  # Request Timeout
-            return Status.TIMEOUT
-        case 429:  # Too Many Requests
-            return Status.THROTTLED
-        case 501:  # Not Implemented
-            return Status.PERMANENT_ERROR
+    if code == 400:  # Bad Request
+        return Status.INVALID_ARGUMENT
+    elif code == 401:  # Unauthorized
+        return Status.UNAUTHENTICATED
+    elif code == 403:  # Forbidden
+        return Status.PERMISSION_DENIED
+    elif code == 404:  # Not Found
+        return Status.NOT_FOUND
+    elif code == 408:  # Request Timeout
+        return Status.TIMEOUT
+    elif code == 429:  # Too Many Requests
+        return Status.THROTTLED
+    elif code == 501:  # Not Implemented
+        return Status.PERMANENT_ERROR
 
     category = code // 100
-    match category:
-        case 1:  # 1xx informational
-            return Status.PERMANENT_ERROR
-        case 2:  # 2xx success
-            return Status.OK
-        case 3:  # 3xx redirection
-            return Status.PERMANENT_ERROR
-        case 4:  # 4xx client error
-            return Status.PERMANENT_ERROR
-        case 5:  # 5xx server error
-            return Status.TEMPORARY_ERROR
+    if category == 1:  # 1xx informational
+        return Status.PERMANENT_ERROR
+    elif category == 2:  # 2xx success
+        return Status.OK
+    elif category == 3:  # 3xx redirection
+        return Status.PERMANENT_ERROR
+    elif category == 4:  # 4xx client error
+        return Status.PERMANENT_ERROR
+    elif category == 5:  # 5xx server error
+        return Status.TEMPORARY_ERROR
 
     return Status.UNSPECIFIED

--- a/src/dispatch/integrations/httpx.py
+++ b/src/dispatch/integrations/httpx.py
@@ -6,15 +6,14 @@ from dispatch.status import Status, register_error_type, register_output_type
 
 def httpx_error_status(error: Exception) -> Status:
     # See https://www.python-httpx.org/exceptions/
-    match error:
-        case httpx.HTTPStatusError():
-            return httpx_response_status(error.response)
-        case httpx.InvalidURL():
-            return Status.INVALID_ARGUMENT
-        case httpx.UnsupportedProtocol():
-            return Status.INVALID_ARGUMENT
-        case httpx.TimeoutException():
-            return Status.TIMEOUT
+    if isinstance(error, httpx.HTTPStatusError):
+        return httpx_response_status(error.response)
+    elif isinstance(error, httpx.InvalidURL):
+        return Status.INVALID_ARGUMENT
+    elif isinstance(error, httpx.UnsupportedProtocol):
+        return Status.INVALID_ARGUMENT
+    elif isinstance(error, httpx.TimeoutException):
+        return Status.TIMEOUT
 
     return Status.TEMPORARY_ERROR
 

--- a/src/dispatch/integrations/openai.py
+++ b/src/dispatch/integrations/openai.py
@@ -6,11 +6,10 @@ from dispatch.status import Status, register_error_type
 
 def openai_error_status(error: Exception) -> Status:
     # See https://github.com/openai/openai-python/blob/main/src/openai/_exceptions.py
-    match error:
-        case openai.APITimeoutError():
-            return Status.TIMEOUT
-        case openai.APIStatusError():
-            return http_response_code_status(error.status_code)
+    if isinstance(error, openai.APITimeoutError):
+        return Status.TIMEOUT
+    elif isinstance(error, openai.APIStatusError):
+        return http_response_code_status(error.status_code)
 
     return Status.TEMPORARY_ERROR
 

--- a/src/dispatch/integrations/requests.py
+++ b/src/dispatch/integrations/requests.py
@@ -7,14 +7,15 @@ from dispatch.status import Status, register_error_type, register_output_type
 def requests_error_status(error: Exception) -> Status:
     # See https://requests.readthedocs.io/en/latest/api/#exceptions
     # and https://requests.readthedocs.io/en/latest/_modules/requests/exceptions/
-    match error:
-        case requests.HTTPError():
-            if error.response is not None:
-                return requests_response_status(error.response)
-        case requests.Timeout():
-            return Status.TIMEOUT
-        case ValueError():  # base class of things like requests.InvalidURL, etc.
-            return Status.INVALID_ARGUMENT
+    if isinstance(error, requests.HTTPError):
+        if error.response is not None:
+            return requests_response_status(error.response)
+    elif isinstance(error, requests.Timeout):
+        return Status.TIMEOUT
+    elif isinstance(
+        error, ValueError
+    ):  # base class of things like requests.InvalidURL, etc.
+        return Status.INVALID_ARGUMENT
 
     return Status.TEMPORARY_ERROR
 

--- a/src/dispatch/integrations/slack.py
+++ b/src/dispatch/integrations/slack.py
@@ -8,10 +8,8 @@ from dispatch.status import Status, register_error_type, register_output_type
 
 def slack_error_status(error: Exception) -> Status:
     # See https://github.com/slackapi/python-slack-sdk/blob/main/slack/errors.py
-    match error:
-        case slack_sdk.errors.SlackApiError():
-            if error.response is not None:
-                return slack_response_status(error.response)
+    if isinstance(error, slack_sdk.errors.SlackApiError) and error.response is not None:
+        return slack_response_status(error.response)
 
     return Status.TEMPORARY_ERROR
 

--- a/src/dispatch/proto.py
+++ b/src/dispatch/proto.py
@@ -297,11 +297,15 @@ class CallResult:
         )
 
     @classmethod
-    def from_value(cls, output: Any, correlation_id: Optional[int] = None) -> CallResult:
+    def from_value(
+        cls, output: Any, correlation_id: Optional[int] = None
+    ) -> CallResult:
         return CallResult(correlation_id=correlation_id, output=output)
 
     @classmethod
-    def from_error(cls, error: Error, correlation_id: Optional[int] = None) -> CallResult:
+    def from_error(
+        cls, error: Error, correlation_id: Optional[int] = None
+    ) -> CallResult:
         return CallResult(correlation_id=correlation_id, error=error)
 
 
@@ -352,7 +356,9 @@ class Error:
         self.value = value
         self.traceback = traceback
         if not traceback and value:
-            self.traceback = "".join(format_exception(value)).encode("utf-8")
+            self.traceback = "".join(
+                format_exception(value.__class__, value, value.__traceback__)
+            ).encode("utf-8")
 
     @classmethod
     def from_exception(cls, ex: Exception, status: Optional[Status] = None) -> Error:

--- a/src/dispatch/proto.py
+++ b/src/dispatch/proto.py
@@ -139,7 +139,7 @@ class Input:
         )
 
 
-@dataclass(slots=True)
+@dataclass
 class Arguments:
     """A container for positional and keyword arguments."""
 
@@ -147,7 +147,7 @@ class Arguments:
     kwargs: dict[str, Any]
 
 
-@dataclass(slots=True)
+@dataclass
 class Output:
     """The output of a primitive function.
 
@@ -240,7 +240,7 @@ class Output:
 # the current Python process.
 
 
-@dataclass(slots=True)
+@dataclass
 class Call:
     """Instruction to call a function.
 
@@ -263,7 +263,7 @@ class Call:
         )
 
 
-@dataclass(slots=True)
+@dataclass
 class CallResult:
     """Result of a Call."""
 
@@ -305,7 +305,7 @@ class CallResult:
         return CallResult(correlation_id=correlation_id, error=error)
 
 
-@dataclass(slots=True)
+@dataclass
 class Error:
     """Error when running a function.
 

--- a/src/dispatch/proto.py
+++ b/src/dispatch/proto.py
@@ -4,7 +4,7 @@ import pickle
 from dataclasses import dataclass
 from traceback import format_exception
 from types import TracebackType
-from typing import Any
+from typing import Any, Optional
 
 import google.protobuf.any_pb2
 import google.protobuf.message
@@ -97,7 +97,7 @@ class Input:
         return self._call_results
 
     @property
-    def poll_error(self) -> Error | None:
+    def poll_error(self) -> Optional[Error]:
         self._assert_resume()
         return self._poll_error
 
@@ -125,7 +125,7 @@ class Input:
         function: str,
         coroutine_state: Any,
         call_results: list[CallResult],
-        error: Error | None = None,
+        error: Optional[Error] = None,
     ):
         return Input(
             req=function_pb.RunRequest(
@@ -163,7 +163,7 @@ class Output:
         self._message = proto
 
     @classmethod
-    def value(cls, value: Any, status: Status | None = None) -> Output:
+    def value(cls, value: Any, status: Optional[Status] = None) -> Output:
         """Terminally exit the function with the provided return value."""
         if status is None:
             status = status_for_output(value)
@@ -183,8 +183,8 @@ class Output:
     @classmethod
     def exit(
         cls,
-        result: CallResult | None = None,
-        tail_call: Call | None = None,
+        result: Optional[CallResult] = None,
+        tail_call: Optional[Call] = None,
         status: Status = Status.OK,
     ) -> Output:
         """Terminally exit the function."""
@@ -201,10 +201,10 @@ class Output:
     def poll(
         cls,
         state: Any,
-        calls: None | list[Call] = None,
+        calls: Optional[list[Call]] = None,
         min_results: int = 1,
         max_results: int = 10,
-        max_wait_seconds: int | None = None,
+        max_wait_seconds: Optional[int] = None,
     ) -> Output:
         """Suspend the function with a set of Calls, instructing the
         orchestrator to resume the function with the provided state when
@@ -249,9 +249,9 @@ class Call:
     """
 
     function: str
-    input: Any | None = None
-    endpoint: str | None = None
-    correlation_id: int | None = None
+    input: Optional[Any] = None
+    endpoint: Optional[str] = None
+    correlation_id: Optional[int] = None
 
     def _as_proto(self) -> call_pb.Call:
         input_bytes = _pb_any_pickle(self.input)
@@ -267,9 +267,9 @@ class Call:
 class CallResult:
     """Result of a Call."""
 
-    correlation_id: int | None = None
-    output: Any | None = None
-    error: Error | None = None
+    correlation_id: Optional[int] = None
+    output: Optional[Any] = None
+    error: Optional[Error] = None
 
     def _as_proto(self) -> call_pb.CallResult:
         output_any = None
@@ -297,11 +297,11 @@ class CallResult:
         )
 
     @classmethod
-    def from_value(cls, output: Any, correlation_id: int | None = None) -> CallResult:
+    def from_value(cls, output: Any, correlation_id: Optional[int] = None) -> CallResult:
         return CallResult(correlation_id=correlation_id, output=output)
 
     @classmethod
-    def from_error(cls, error: Error, correlation_id: int | None = None) -> CallResult:
+    def from_error(cls, error: Error, correlation_id: Optional[int] = None) -> CallResult:
         return CallResult(correlation_id=correlation_id, error=error)
 
 
@@ -316,16 +316,16 @@ class Error:
     status: Status
     type: str
     message: str
-    value: Exception | None = None
-    traceback: bytes | None = None
+    value: Optional[Exception] = None
+    traceback: Optional[bytes] = None
 
     def __init__(
         self,
         status: Status,
         type: str,
         message: str,
-        value: Exception | None = None,
-        traceback: bytes | None = None,
+        value: Optional[Exception] = None,
+        traceback: Optional[bytes] = None,
     ):
         """Create a new Error.
 
@@ -355,7 +355,7 @@ class Error:
             self.traceback = "".join(format_exception(value)).encode("utf-8")
 
     @classmethod
-    def from_exception(cls, ex: Exception, status: Status | None = None) -> Error:
+    def from_exception(cls, ex: Exception, status: Optional[Status] = None) -> Error:
         """Create an Error from a Python exception, using its class qualified
         named as type.
 

--- a/src/dispatch/scheduler.py
+++ b/src/dispatch/scheduler.py
@@ -2,7 +2,8 @@ import logging
 import pickle
 import sys
 from dataclasses import dataclass, field
-from typing import Any, Awaitable, Callable, Protocol, Optional, Union
+from typing import Any, Awaitable, Callable, Optional, Protocol, Union
+
 from typing_extensions import TypeAlias
 
 from dispatch.coroutine import AllDirective, AnyDirective, AnyException, RaceDirective

--- a/src/dispatch/scheduler.py
+++ b/src/dispatch/scheduler.py
@@ -17,7 +17,7 @@ CoroutineID: TypeAlias = int
 CorrelationID: TypeAlias = int
 
 
-@dataclass(slots=True)
+@dataclass
 class CoroutineResult:
     """The result from running a coroutine to completion."""
 
@@ -26,7 +26,7 @@ class CoroutineResult:
     error: Exception | None = None
 
 
-@dataclass(slots=True)
+@dataclass
 class CallResult:
     """The result of an asynchronous function call."""
 
@@ -47,7 +47,7 @@ class Future(Protocol):
     def value(self) -> Any: ...
 
 
-@dataclass(slots=True)
+@dataclass
 class CallFuture:
     """A future result of a dispatch.coroutine.call() operation."""
 
@@ -78,7 +78,7 @@ class CallFuture:
         return self.result.value
 
 
-@dataclass(slots=True)
+@dataclass
 class AllFuture:
     """A future result of a dispatch.coroutine.all() operation."""
 
@@ -120,7 +120,7 @@ class AllFuture:
         return [self.results[id].value for id in self.order]
 
 
-@dataclass(slots=True)
+@dataclass
 class AnyFuture:
     """A future result of a dispatch.coroutine.any() operation."""
 
@@ -177,7 +177,7 @@ class AnyFuture:
         return self.first_result.value
 
 
-@dataclass(slots=True)
+@dataclass
 class RaceFuture:
     """A future result of a dispatch.coroutine.race() operation."""
 
@@ -217,7 +217,7 @@ class RaceFuture:
         return self.first_result.value if self.first_result else None
 
 
-@dataclass(slots=True)
+@dataclass
 class Coroutine:
     """An in-flight coroutine."""
 
@@ -241,7 +241,7 @@ class Coroutine:
         return f"Coroutine({self.id}, {self.coroutine.__qualname__})"
 
 
-@dataclass(slots=True)
+@dataclass
 class State:
     """State of the scheduler and the coroutines it's managing."""
 

--- a/src/dispatch/signature/digest.py
+++ b/src/dispatch/signature/digest.py
@@ -1,11 +1,12 @@
 import hashlib
 import hmac
+from typing import Union
 
 import http_sfv
 from http_message_signatures import InvalidSignature
 
 
-def generate_content_digest(body: str | bytes) -> str:
+def generate_content_digest(body: Union[str, bytes]) -> str:
     """Returns a SHA-512 Content-Digest header, according to
     https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-digest-headers-13
     """
@@ -16,7 +17,7 @@ def generate_content_digest(body: str | bytes) -> str:
     return str(http_sfv.Dictionary({"sha-512": digest}))
 
 
-def verify_content_digest(digest_header: str | bytes, body: str | bytes):
+def verify_content_digest(digest_header: Union[str, bytes], body: Union[str, bytes]):
     """Verify a SHA-256 or SHA-512 Content-Digest header matches a
     request body."""
     if isinstance(body, str):

--- a/src/dispatch/signature/key.py
+++ b/src/dispatch/signature/key.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Union, Optional
+from typing import Optional, Union
 
 from cryptography.hazmat.primitives.asymmetric.ed25519 import (
     Ed25519PrivateKey,

--- a/src/dispatch/signature/key.py
+++ b/src/dispatch/signature/key.py
@@ -48,7 +48,7 @@ def private_key_from_bytes(key: bytes) -> Ed25519PrivateKey:
     return Ed25519PrivateKey.from_private_bytes(key)
 
 
-@dataclass(slots=True)
+@dataclass
 class KeyResolver(HTTPSignatureKeyResolver):
     """KeyResolver provides public and private keys.
 

--- a/src/dispatch/signature/key.py
+++ b/src/dispatch/signature/key.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Union, Optional
 
 from cryptography.hazmat.primitives.asymmetric.ed25519 import (
     Ed25519PrivateKey,
@@ -11,7 +12,7 @@ from cryptography.hazmat.primitives.serialization import (
 from http_message_signatures import HTTPSignatureKeyResolver
 
 
-def public_key_from_pem(pem: str | bytes) -> Ed25519PublicKey:
+def public_key_from_pem(pem: Union[str, bytes]) -> Ed25519PublicKey:
     """Returns an Ed25519 public key given a PEM representation."""
     if isinstance(pem, str):
         pem = pem.encode()
@@ -28,7 +29,7 @@ def public_key_from_bytes(key: bytes) -> Ed25519PublicKey:
 
 
 def private_key_from_pem(
-    pem: str | bytes, password: bytes | None = None
+    pem: Union[str, bytes], password: Optional[bytes] = None
 ) -> Ed25519PrivateKey:
     """Returns an Ed25519 private key given a PEM representation
     and optional password."""
@@ -57,8 +58,8 @@ class KeyResolver(HTTPSignatureKeyResolver):
     """
 
     key_id: str
-    public_key: Ed25519PublicKey | None = None
-    private_key: Ed25519PrivateKey | None = None
+    public_key: Optional[Ed25519PublicKey] = None
+    private_key: Optional[Ed25519PrivateKey] = None
 
     def resolve_public_key(self, key_id: str):
         if key_id != self.key_id or self.public_key is None:

--- a/src/dispatch/signature/request.py
+++ b/src/dispatch/signature/request.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Union
 
 from http_message_signatures.structures import CaseInsensitiveDict
 
@@ -10,4 +11,4 @@ class Request:
     method: str
     url: str
     headers: CaseInsensitiveDict
-    body: str | bytes
+    body: Union[str, bytes]

--- a/src/dispatch/signature/request.py
+++ b/src/dispatch/signature/request.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from http_message_signatures.structures import CaseInsensitiveDict
 
 
-@dataclass(slots=True)
+@dataclass
 class Request:
     """A framework-agnostic representation of an HTTP request."""
 

--- a/src/dispatch/status.py
+++ b/src/dispatch/status.py
@@ -92,27 +92,31 @@ def status_for_error(error: Exception) -> Status:
     # If not, resort to standard error categorization.
     #
     # See https://docs.python.org/3/library/exceptions.html
-    match error:
-        case IncompatibleStateError():
-            return Status.INCOMPATIBLE_STATE
-        case TimeoutError():
-            return Status.TIMEOUT
-        case TypeError() | ValueError():
-            return Status.INVALID_ARGUMENT
-        case ConnectionError():
-            return Status.TCP_ERROR
-        case PermissionError():
-            return Status.PERMISSION_DENIED
-        case FileNotFoundError():
-            return Status.NOT_FOUND
-        case EOFError() | InterruptedError() | KeyboardInterrupt() | OSError():
-            # For OSError, we might want to categorize the values of errnon
-            # to determine whether the error is temporary or permanent.
-            #
-            # In general, permanent errors from the OS are rare because they
-            # tend to be caused by invalid use of syscalls, which are
-            # unlikely at higher abstraction levels.
-            return Status.TEMPORARY_ERROR
+    if isinstance(error, IncompatibleStateError):
+        return Status.INCOMPATIBLE_STATE
+    elif isinstance(error, TimeoutError):
+        return Status.TIMEOUT
+    elif isinstance(error, TypeError) or isinstance(error, ValueError):
+        return Status.INVALID_ARGUMENT
+    elif isinstance(error, ConnectionError):
+        return Status.TCP_ERROR
+    elif isinstance(error, PermissionError):
+        return Status.PERMISSION_DENIED
+    elif isinstance(error, FileNotFoundError):
+        return Status.NOT_FOUND
+    elif (
+        isinstance(error, EOFError)
+        or isinstance(error, InterruptedError)
+        or isinstance(error, KeyboardInterrupt)
+        or isinstance(error, OSError)
+    ):
+        # For OSError, we might want to categorize the values of errnon
+        # to determine whether the error is temporary or permanent.
+        #
+        # In general, permanent errors from the OS are rare because they
+        # tend to be caused by invalid use of syscalls, which are
+        # unlikely at higher abstraction levels.
+        return Status.TEMPORARY_ERROR
     return Status.PERMANENT_ERROR
 
 

--- a/src/dispatch/test/client.py
+++ b/src/dispatch/test/client.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Optional
 
 import fastapi
 import grpc
@@ -25,7 +26,7 @@ class EndpointClient:
     """
 
     def __init__(
-        self, http_client: httpx.Client, signing_key: Ed25519PrivateKey | None = None
+        self, http_client: httpx.Client, signing_key: Optional[Ed25519PrivateKey] = None
     ):
         """Initialize the client.
 
@@ -48,14 +49,14 @@ class EndpointClient:
         return self._stub.Run(request)
 
     @classmethod
-    def from_url(cls, url: str, signing_key: Ed25519PrivateKey | None = None):
+    def from_url(cls, url: str, signing_key: Optional[Ed25519PrivateKey] = None):
         """Returns an EndpointClient for a Dispatch endpoint URL."""
         http_client = httpx.Client(base_url=url)
         return EndpointClient(http_client, signing_key)
 
     @classmethod
     def from_app(
-        cls, app: fastapi.FastAPI, signing_key: Ed25519PrivateKey | None = None
+        cls, app: fastapi.FastAPI, signing_key: Optional[Ed25519PrivateKey] = None
     ):
         """Returns an EndpointClient for a Dispatch endpoint bound to a
         FastAPI app instance."""
@@ -65,7 +66,7 @@ class EndpointClient:
 
 class _HttpxGrpcChannel(grpc.Channel):
     def __init__(
-        self, http_client: httpx.Client, signing_key: Ed25519PrivateKey | None = None
+        self, http_client: httpx.Client, signing_key: Optional[Ed25519PrivateKey] = None
     ):
         self.http_client = http_client
         self.signing_key = signing_key
@@ -113,7 +114,7 @@ class _UnaryUnaryMultiCallable(grpc.UnaryUnaryMultiCallable):
         method,
         request_serializer,
         response_deserializer,
-        signing_key: Ed25519PrivateKey | None = None,
+        signing_key: Optional[Ed25519PrivateKey] = None,
     ):
         self.client = client
         self.method = method

--- a/src/dispatch/test/service.py
+++ b/src/dispatch/test/service.py
@@ -6,10 +6,10 @@ import time
 from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Optional
-from typing_extensions import TypeAlias
 
 import grpc
 import httpx
+from typing_extensions import TypeAlias
 
 import dispatch.sdk.v1.call_pb2 as call_pb
 import dispatch.sdk.v1.dispatch_pb2 as dispatch_pb
@@ -87,11 +87,11 @@ class DispatchService(dispatch_grpc.DispatchServiceServicer):
         self.pollers: dict[DispatchID, Poller] = {}
         self.parents: dict[DispatchID, Poller] = {}
 
-        self.roundtrips: OrderedDict[DispatchID, list[RoundTrip]] | None = None
+        self.roundtrips: Optional[OrderedDict[DispatchID, list[RoundTrip]]] = None
         if collect_roundtrips:
             self.roundtrips = OrderedDict()
 
-        self._thread: threading.Optional[Thread] = None
+        self._thread: Optional[threading.Thread] = None
         self._stop_event = threading.Event()
         self._work_signal = threading.Condition()
 

--- a/src/dispatch/test/service.py
+++ b/src/dispatch/test/service.py
@@ -5,7 +5,8 @@ import threading
 import time
 from collections import OrderedDict
 from dataclasses import dataclass
-from typing import TypeAlias
+from typing import Optional
+from typing_extensions import TypeAlias
 
 import grpc
 import httpx
@@ -52,8 +53,8 @@ class DispatchService(dispatch_grpc.DispatchServiceServicer):
     def __init__(
         self,
         endpoint_client: EndpointClient,
-        api_key: str | None = None,
-        retry_on_status: set[Status] | None = None,
+        api_key: Optional[str] = None,
+        retry_on_status: Optional[set[Status]] = None,
         collect_roundtrips: bool = False,
     ):
         """Initialize the Dispatch service.
@@ -90,7 +91,7 @@ class DispatchService(dispatch_grpc.DispatchServiceServicer):
         if collect_roundtrips:
             self.roundtrips = OrderedDict()
 
-        self._thread: threading.Thread | None = None
+        self._thread: threading.Optional[Thread] = None
         self._stop_event = threading.Event()
         self._work_signal = threading.Condition()
 

--- a/src/dispatch/test/service.py
+++ b/src/dispatch/test/service.py
@@ -143,13 +143,12 @@ class DispatchService(dispatch_grpc.DispatchServiceServicer):
         while self.queue:
             dispatch_id, request, call_type = self.queue.pop(0)
 
-            match call_type:
-                case CallType.CALL:
-                    logger.info("calling function %s", request.function)
-                case CallType.RESUME:
-                    logger.info("resuming function %s", request.function)
-                case CallType.RETRY:
-                    logger.info("retrying function %s", request.function)
+            if call_type == CallType.CALL:
+                logger.info("calling function %s", request.function)
+            elif call_type == CallType.RESUME:
+                logger.info("resuming function %s", request.function)
+            elif call_type == CallType.RETRY:
+                logger.info("retrying function %s", request.function)
 
             try:
                 response = self.endpoint_client.run(request)

--- a/tests/dispatch/experimental/durable/test_frame.py
+++ b/tests/dispatch/experimental/durable/test_frame.py
@@ -28,14 +28,6 @@ async def coroutine(a):
     await Yields(a)
 
 
-async def async_generator(a):
-    await Yields(a)
-    a += 1
-    yield a
-    a += 1
-    await Yields(a)
-
-
 class TestFrame(unittest.TestCase):
     def test_generator_copy(self):
         # Create an instance and run it to the first yield point.
@@ -72,39 +64,6 @@ class TestFrame(unittest.TestCase):
 
         # Original coroutine is not affected.
         assert next(g) == 2
-        assert next(g) == 3
-
-    def test_async_generator_copy(self):
-        # Create an instance and run it to the first yield point.
-        ag = async_generator(1)
-        next_awaitable = anext(ag)
-        g = next_awaitable.__await__()
-        assert next(g) == 1
-
-        # Copy the async generator.
-        ag2 = async_generator(1)
-        self.copy_to(ag, ag2)
-        next_awaitable2 = anext(ag2)
-        g2 = next_awaitable2.__await__()
-
-        # The copy should start from where the previous generator was suspended.
-        try:
-            next(g2)
-            raise RuntimeError
-        except StopIteration as e:
-            assert e.value == 2
-        next_awaitable2 = anext(ag2)
-        g2 = next_awaitable2.__await__()
-        assert next(g2) == 3
-
-        # Original generator is not affected.
-        try:
-            next(g)
-            raise RuntimeError
-        except StopIteration as e:
-            assert e.value == 2
-        next_awaitable = anext(ag)
-        g = next_awaitable.__await__()
         assert next(g) == 3
 
     def copy_to(self, from_obj, to_obj):

--- a/tests/dispatch/test_error.py
+++ b/tests/dispatch/test_error.py
@@ -12,7 +12,13 @@ class TestError(unittest.TestCase):
         except Exception as e:
             original_exception = e
             error = Error.from_exception(e)
-        original_traceback = "".join(traceback.format_exception(original_exception))
+        original_traceback = "".join(
+            traceback.format_exception(
+                original_exception.__class__,
+                original_exception,
+                original_exception.__traceback__,
+            )
+        )
 
         # For some reasons traceback.format_exception does not include the caret
         # (^) in the original traceback, but it does in the reconstructed one,
@@ -24,7 +30,13 @@ class TestError(unittest.TestCase):
 
         reconstructed_exception = error.to_exception()
         reconstructed_traceback = strip_caret(
-            "".join(traceback.format_exception(reconstructed_exception))
+            "".join(
+                traceback.format_exception(
+                    reconstructed_exception.__class__,
+                    reconstructed_exception,
+                    reconstructed_exception.__traceback__,
+                )
+            )
         )
 
         assert type(reconstructed_exception) is type(original_exception)
@@ -34,7 +46,13 @@ class TestError(unittest.TestCase):
         error2 = Error.from_exception(reconstructed_exception)
         reconstructed_exception2 = error2.to_exception()
         reconstructed_traceback2 = strip_caret(
-            "".join(traceback.format_exception(reconstructed_exception2))
+            "".join(
+                traceback.format_exception(
+                    reconstructed_exception2.__class__,
+                    reconstructed_exception2,
+                    reconstructed_exception2.__traceback__,
+                )
+            )
         )
 
         assert type(reconstructed_exception2) is type(original_exception)

--- a/tests/dispatch/test_scheduler.py
+++ b/tests/dispatch/test_scheduler.py
@@ -1,5 +1,5 @@
 import unittest
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 
 from dispatch.coroutine import AnyException, any, call, gather, race
 from dispatch.experimental.durable import durable
@@ -414,7 +414,7 @@ class TestOneShotScheduler(unittest.TestCase):
         main: Callable,
         prev_output: Output,
         call_results: list[CallResult],
-        poll_error: Exception | None = None,
+        poll_error: Optional[Exception] = None,
     ):
         poll = self.assert_poll(prev_output)
         input = Input.from_poll_results(
@@ -444,7 +444,7 @@ class TestOneShotScheduler(unittest.TestCase):
         self.assertEqual(expect, any_unpickle(result.output))
 
     def assert_exit_result_error(
-        self, output: Output, expect: type[Exception], message: str | None = None
+        self, output: Output, expect: type[Exception], message: Optional[str] = None
     ):
         result = self.assert_exit_result(output)
         self.assertFalse(result.HasField("output"))


### PR DESCRIPTION
This PR adds support for Python 3.9.

I had to refactor to avoid things only available in 3.10+:
* `match` ([PEP 636](https://peps.python.org/pep-0636/))
* union types ([PEP 604](https://peps.python.org/pep-0604/))
* `@dataclass(slots=True)`
* `traceback.format_exception` with a single argument

I could add `__slots__` manually, but I think this is in premature optimization territory.

This fixes #43.