### PR TITLE
Add MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,15 @@
+graft src
+graft test
+graft example
+
+include pyproject.toml
+include setup.py
+include README.md
+include CONTRIBUTING.md
+include LICENSE
+include Makefile
+include mkdocs.yml
+
+global-exclude *.so
+global-exclude *.py[cod]
+global-exclude __pycache__


### PR DESCRIPTION
In #136 we split the C extension across `frame.c` and a few header files.

When `setuptools` tries to build the extension it doesn't seem to know about the headers. According to https://setuptools.pypa.io/en/latest/userguide/miscellaneous.html#controlling-files-in-the-distribution we need to bundle a `MANIFEST.in` file which tells setuptools what files are included in the sdist. The manifest I've provided copies the entire src directory via `graft src`. The build now succeeds.