### PR TITLE
Don't test ./examples by default

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,21 @@ jobs:
     - run: make dev
     - run: make test
 
+  examples:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: ['3.12']
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python }}
+        cache: pip
+    - run: make dev
+    - run: make exampletest
+
   format:
     runs-on: ubuntu-latest
     strategy:

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,10 @@ typecheck:
 	$(PYTHON) -m mypy src tests
 
 unittest:
-	$(PYTHON) -m pytest
+	$(PYTHON) -m pytest tests
+
+exampletest:
+	$(PYTHON) -m pytest examples
 
 coverage: typecheck
 	coverage run -m unittest discover

--- a/tests/examples
+++ b/tests/examples
@@ -1,1 +1,0 @@
-../examples


### PR DESCRIPTION
Running `make test` checks types with `mypy`, then runs tests found in the `./tests` directory. At the moment we symlink `./examples` as `./test/examples` so that we test the examples when running `make test`.

Given that our build matrix is growing (#136, #140, #143), we may run into a situation where the examples hit rate limits when run for each Python version, causing CI to fail. For this reason, I've removed the symlink so that we don't test examples by default.

I've added a new make command that tests the examples. We can run this locally as necessary. To ensure we at least have some coverage, I've added a single CI run that will test the examples using Python 3.12 only. 