### PR TITLE
add special Reset class to implement tail calls

### DIFF
--- a/src/dispatch/__init__.py
+++ b/src/dispatch/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import dispatch.integrations
 from dispatch.coroutine import all, any, call, gather, race
-from dispatch.function import DEFAULT_API_URL, Client, Registry
+from dispatch.function import DEFAULT_API_URL, Client, Registry, Reset
 from dispatch.id import DispatchID
 from dispatch.proto import Call, Error, Input, Output
 from dispatch.status import Status
@@ -17,6 +17,7 @@ __all__ = [
     "Output",
     "Call",
     "Error",
+    "Reset",
     "Status",
     "call",
     "gather",

--- a/src/dispatch/function.py
+++ b/src/dispatch/function.py
@@ -27,7 +27,7 @@ import dispatch.sdk.v1.dispatch_pb2 as dispatch_pb
 import dispatch.sdk.v1.dispatch_pb2_grpc as dispatch_grpc
 from dispatch.experimental.durable import durable
 from dispatch.id import DispatchID
-from dispatch.proto import Arguments, Call, Error, Input, Output
+from dispatch.proto import Arguments, Call, Error, Input, Output, TailCall
 from dispatch.scheduler import OneShotScheduler
 
 logger = logging.getLogger(__name__)
@@ -155,6 +155,14 @@ class Function(PrimitiveFunction, Generic[P, T]):
         return self._build_primitive_call(
             Arguments(args, kwargs), correlation_id=correlation_id
         )
+
+
+class Reset(TailCall):
+    """The current coroutine is aborted and scheduling reset to be replaced with
+    the call embedded in this exception."""
+
+    def __init__(self, func: Function[P, T], *args: P.args, **kwargs: P.kwargs):
+        super().__init__(call=func.build_call(*args, correlation_id=None, **kwargs))
 
 
 class Registry:

--- a/src/dispatch/scheduler.py
+++ b/src/dispatch/scheduler.py
@@ -31,14 +31,6 @@ CorrelationID: TypeAlias = int
 
 
 @dataclass
-class Reset(Exception):
-    """A reset exception which discards the current coroutine and schedules
-    the provided call as argument instead"""
-
-    def __init__(self): ...
-
-
-@dataclass
 class CoroutineResult:
     """The result from running a coroutine to completion."""
 

--- a/src/dispatch/scheduler.py
+++ b/src/dispatch/scheduler.py
@@ -20,7 +20,7 @@ from typing_extensions import TypeAlias
 from dispatch.coroutine import AllDirective, AnyDirective, AnyException, RaceDirective
 from dispatch.error import IncompatibleStateError
 from dispatch.experimental.durable.function import DurableCoroutine, DurableGenerator
-from dispatch.proto import Call, Error, Input, Output
+from dispatch.proto import Call, Error, Input, Output, TailCall
 from dispatch.status import Status
 
 logger = logging.getLogger(__name__)
@@ -31,12 +31,22 @@ CorrelationID: TypeAlias = int
 
 
 @dataclass
+class Reset(Exception):
+    """A reset exception which discards the current coroutine and schedules
+    the provided call as argument instead"""
+
+    def __init__(self): ...
+
+
+@dataclass
 class CoroutineResult:
     """The result from running a coroutine to completion."""
 
     coroutine_id: CoroutineID
     value: Optional[Any] = None
     error: Optional[Exception] = None
+    call: Optional[Call] = None
+    status: Status = Status.OK
 
 
 @dataclass
@@ -438,6 +448,10 @@ class OneShotScheduler:
             coroutine_result: Optional[CoroutineResult] = None
             try:
                 coroutine_yield = coroutine.run()
+            except TailCall as tc:
+                coroutine_result = CoroutineResult(
+                    coroutine_id=coroutine.id, call=tc.call, status=tc.status
+                )
             except StopIteration as e:
                 coroutine_result = CoroutineResult(
                     coroutine_id=coroutine.id, value=e.value
@@ -450,7 +464,11 @@ class OneShotScheduler:
 
             # Handle coroutines that return or raise.
             if coroutine_result is not None:
-                if coroutine_result.error is not None:
+                if coroutine_result.call is not None:
+                    logger.debug(
+                        "%s reset to %s", coroutine, coroutine_result.call.function
+                    )
+                elif coroutine_result.error is not None:
                     logger.debug("%s raised %s", coroutine, coroutine_result.error)
                 else:
                     logger.debug("%s returned %s", coroutine, coroutine_result.value)
@@ -462,6 +480,11 @@ class OneShotScheduler:
                     if coroutine_result.error is not None:
                         return Output.error(
                             Error.from_exception(coroutine_result.error)
+                        )
+                    if coroutine_result.call is not None:
+                        return Output.tail_call(
+                            tail_call=coroutine_result.call,
+                            status=coroutine_result.status,
                         )
                     return Output.value(coroutine_result.value)
 


### PR DESCRIPTION
This PR adds a new `Reset` type which is intended to be used to allow resetting the current coroutine execution to a different pair of function and arguments.

In the inner layers of the SDK, this construct gets turned into a tail call with a temporary error status to communicate the failure to the scheduler (and apply back-pressure) while also changing the input arguments.