### PR TITLE
Don't pickle coroutine state twice

### DIFF
--- a/src/dispatch/scheduler.py
+++ b/src/dispatch/scheduler.py
@@ -558,7 +558,7 @@ class OneShotScheduler:
             len(serialized_state),
         )
         return Output.poll(
-            state=serialized_state,
+            coroutine_state=serialized_state,
             calls=pending_calls,
             min_results=max(1, min(state.outstanding_calls, self.poll_min_results)),
             max_results=max(1, min(state.outstanding_calls, self.poll_max_results)),


### PR DESCRIPTION
Coroutine state is currently pickled twice, [here](https://github.com/stealthrocket/dispatch-py/blob/c9cdf68b891e5bf09ab008870d01f95842033c87/src/dispatch/scheduler.py#L544) and [here](https://github.com/stealthrocket/dispatch-py/blob/main/src/dispatch/proto.py#L232). This PR fixes the issue by requiring that coroutine state is bytes when it reaches the latter. This allows the bundled scheduler to be responsible for serializing the state, where it can check that the state is valid and raise an `IncompatibleStateError` otherwise.