### PR TITLE
Bump cibuildwheel version to fix PyPI publish issue

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -44,7 +44,7 @@ jobs:
         - macos-14
     steps:
     - uses: actions/checkout@v4
-    - uses: pypa/cibuildwheel@v2.16.5
+    - uses: pypa/cibuildwheel@v2.17.0
       env:
         CIBW_BUILD: ${{ matrix.build }}-*
     - uses: actions/upload-artifact@v4
@@ -71,7 +71,7 @@ jobs:
     - uses: docker/setup-qemu-action@v3
       with:
         platforms: all
-    - uses: pypa/cibuildwheel@v2.16.5
+    - uses: pypa/cibuildwheel@v2.17.0
       env:
         CIBW_BUILD: ${{ matrix.build }}-*
         CIBW_ARCHS: ${{ matrix.arch }}


### PR DESCRIPTION
https://github.com/pypa/cibuildwheel/releases/tag/v2.17.0 includes a fix (https://github.com/pypa/cibuildwheel/pull/1745) for the issue we're seeing building wheels and publishing to PyPI: https://github.com/stealthrocket/dispatch-py/actions/runs/8532064505